### PR TITLE
Add component for user-notifications

### DIFF
--- a/assets/components/user-notifications/element.js
+++ b/assets/components/user-notifications/element.js
@@ -1,0 +1,42 @@
+export class UserNotifications extends HTMLElement {
+  connectedCallback() {
+    if (!this.entries) {
+      return;
+    }
+    this.hidden = false;
+
+    document.body.addEventListener("session-suggested", this.addNotification.bind(this));
+  }
+
+  addNotification(ev) {
+    const session = ev.detail["spacy.app/session"];
+    const notification = this.newNotification(ev.type);
+
+    if (!session || session.sponsor !== this.currentUser || !notification) {
+      return; // Add no notifications for things we don't understand
+    }
+
+    notification.querySelector("[data-slot=title]").textContent = session.title;
+    notification.querySelector("[data-slot=at").textContent = new Date().toLocaleString(); // TODO: formatting, use Crux timestamp?
+
+    this.entries.appendChild(notification);
+  }
+
+  get entries() {
+    return this.querySelector("ul");
+  }
+
+  get currentUser() {
+    return this.getAttribute("current-user");
+  }
+
+  newNotification(fact) {
+    const template = this.querySelector(`template[data-template=${fact}]`);
+    if (!template) {
+      return;
+    }
+    return template.content
+      .querySelector("*") // Find first true HTML node which will be our session markup
+      .cloneNode(true);
+  }
+}

--- a/assets/components/user-notifications/index.js
+++ b/assets/components/user-notifications/index.js
@@ -1,0 +1,3 @@
+import { UserNotifications } from "./element";
+
+customElements.define("user-notifications", UserNotifications);

--- a/assets/components/user-notifications/index.scss
+++ b/assets/components/user-notifications/index.scss
@@ -1,0 +1,10 @@
+user-notifications {
+  details {
+    margin-top: $spacer-sm;
+  }
+
+  [data-slot=at] {
+    color: gray;
+    font-size: $font-size-sm;
+  }
+}

--- a/assets/components/waiting-queue/element.js
+++ b/assets/components/waiting-queue/element.js
@@ -5,7 +5,7 @@ export class WaitingQueue extends HTMLElement {
     }
 
     this.form.addEventListener("submit", this.submitForm.bind(this));
-    document.body.addEventListener("session-scheduled", this.addQueuedSession.bind(this));
+    document.body.addEventListener("session-suggested", this.addQueuedSession.bind(this));
   }
 
   submitForm(ev) {
@@ -41,6 +41,8 @@ export class WaitingQueue extends HTMLElement {
   }
 
   newSession() {
-    return this.querySelector("template").content.querySelector("*").cloneNode(true);
+    return this.querySelector("template").content
+      .querySelector("*") // Find first true HTML node which will be our session markup
+      .cloneNode(true);
   }
 }

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -1,4 +1,7 @@
 import "hijax-form";
 
+import "../components/user-notifications";
 import "../components/fact-handler";
 import "../components/waiting-queue";
+
+document.body.classList.add("js");

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -1,0 +1,9 @@
+$font-size-sm: 0.875rem;
+
+$spacer-xss: 0.25rem;
+$spacer-xs: 0.5rem;
+$spacer-sm: 0.75rem;
+$spacer-base: 1.25rem;
+$spacer-md: 2rem;
+$spacer-lg: 3.25rem;
+$spacer-xl: 5.25rem;

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,5 +1,11 @@
-details {
-  h2 {
-    display: inline-block;
-  }
+@import "./variables";
+
+body {
+  font-family: -apple-system, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
+
+body:not(.js) .js-only {
+  display: none;
+}
+
+@import "../components/user-notifications/";

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -4,11 +4,21 @@
 {% endblock %}
 {% block body %}
 
-<main data-current-user="{{current-user}}">
+<header>
     <h1>{{session-name}}</h1>
 
-    <first-of-line>
-        <h2>Up Next</h2>
+    <nav>
+        <ul>
+            <li><a href="#up-next">Up Next</a></li>
+            <li><a href="#sessions">Sessions</a></li>
+            <li><a href="#queue">Queue</a></li>
+            <li class="js-only"><a href="#notifications">Notifications</a></li>
+        </ul>
+    </nav>
+</header>
+<main>
+    <up-next current-user="{{current-user}}">
+        <h2 id="up-next">Up Next</h2>
         {% if next-up %}
 
         <details id="{{next-up.session.id}}">
@@ -16,10 +26,16 @@
             {{next-up.session.description}}
         </details>
 
+        <p role="status">
+            {% ifequal next-up.sponsor current-user %}
+            You are currently next in line! Please select a slot for your session.
+            {% endifequal %}
+        </p>
+
         {% endif %}
-    </first-of-line>
+    </up-next>
     <bulletin-board>
-        <h2>Session Plan</h2>
+        <h2 id="sessions">Sessions</h2>
         <table>
             <thead>
                 <tr>
@@ -59,7 +75,7 @@
         </table>
     </bulletin-board>
     <waiting-queue>
-        <h2>Queue</h2>
+        <h2 id="queue">Queue</h2>
         <ol>
             {% for item in waiting-queue %}
             <li>
@@ -96,6 +112,17 @@
             </li>
         </template>
     </waiting-queue>
+    <user-notifications current-user="{{current-user}}" hidden role="log">
+        <h2 id="notifications">Notifications</h2>
+        <ul role="log"></ul>
+
+        <template data-template="session-suggested">
+            <li>
+                Your session "<span data-slot="title"></span>" was received and placed in the queue
+                <div data-slot="at"></div>
+            </li>
+        </template>
+    </user-notifications>
     <fact-handler uri="{{uris.spacy..app/sse}}"></fact-handler>
 </main>
 {% endblock %}

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -68,7 +68,7 @@
   (let [id (random-uuid)
         current-user "joy" ;; TODO - retrieve from header
         new-session {:sponsor current-user :session (assoc session :id id)}
-        new-facts [{::fact :session-scheduled
+        new-facts [{::fact :session-suggested
                     ::session {:id id :title title :description description :sponsor current-user}}]]
     (-> state
         (update-in [:waiting-queue] #(concat % [new-session]))


### PR DESCRIPTION
With this commit I add a section to the UI for user notifications.
This section contains a List with the role=log attribute, which
means that when messages are added to the notifications, these will
be read out to a user who is using a screenreader.

This component listens to the same event as the waiting-queue element
(although I renamed it in session-suggested instead of
session-scheduled, since that seems more correct to me).

I also added a UI status element to the `Up Next` section. This element
has role=status, which means that when a session moves up in the line,
we need to modify this status. Then it will also be read out to a screen
reader -- I'm not sure if this is the best place for it, but I'm leaving
it there for now.

In the future, the Notifications may be a feature only for screenreaders,
but I am leaving it visible for everyone for now.