### PR TITLE
Put data in Crux

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
    [juxt.modular/aleph "0.1.4"]
    [org.clojure/data.json "1.0.0"]
    [selmer "1.12.31"]
+   [juxt/crux-core "20.09-1.12.1-beta"]
    [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]]
   :repl-options {:init-ns user}
 

--- a/session.edn
+++ b/session.edn
@@ -1,1 +1,13 @@
-{:waiting-queue [{:sponsor "joy", :session {:title "Responsible Web Applications", :description "Developing an application that is responsive and accessible", :id "UUID1"}}], :rooms ["Berlin" "Offenbach" "Monheim"], :times ["10:00 - 11:00" "11:00 - 12:00" "12:00 - 13:00"], :scheduled [{:sponsor "jans", :session {:id "UUID2", :title "Idris", :description "Ich liebe Typen"}, :room "Berlin", :time "10:00 - 11:00"}], :events [["UUID2" :session-title "Idris"] ["UUID2" :description "Ich liebe Typen"] ["UUID-jan" :has-suggested "UUID2"] ["UUID2" :has-room "UUID-Berlin"] ["UUID2" :has-time "UUID-10:00"] ["UUID4" :session-title "Responsible Web Applications"] ["UUID4" :description "Responsive + Accessible"] ["UUID-joy" :has-suggested "UUID4"]]}
+{:spacy.domain/slug "dezember-2020-strategie-event",
+ :spacy.domain/waiting-queue
+ [#:spacy.domain{:sponsor "joy",
+                 :session
+                 #:spacy.domain{:title "Responsible Web Applications",
+                                :description
+                                "Developing an application that is responsive and accessible",
+                                :id
+                                #uuid "70ef7a12-569c-45aa-ad8c-4f4935d289be"}}],
+ :spacy.domain/rooms ["Berlin" "Offenbach" "Monheim"],
+ :spacy.domain/times ["10:00 - 11:00" "11:00 - 12:00" "12:00 - 13:00"],
+ :spacy.domain/schedule [],
+ :spacy.domain/facts []}

--- a/src/spacy/crux.clj
+++ b/src/spacy/crux.clj
@@ -1,0 +1,115 @@
+(ns spacy.crux
+  (:require [crux.api :as crux]
+            [clojure.set :as set]
+            [clojure.walk :as walk]
+            [clojure.edn :as edn]
+            [clojure.pprint :refer [pprint]]
+            [clojure.spec.alpha :as s]
+            [clojure.tools.logging :as log]
+            [clojure.core.async :as async]
+            [com.stuartsierra.component :as component]
+            [spacy.data :as data]
+            [spacy.domain :as domain]))
+
+(defn- random-uuid []
+  (java.util.UUID/randomUUID))
+
+(defn with-crux-id [doc]
+  (assoc doc :crux.db/id (random-uuid)))
+
+(defn- maybe-add-crux-id [doc]
+  (if (:crux.db/id doc)
+    doc
+    (with-crux-id doc)))
+
+(defn- facts [db slug]
+  (let [results (crux/q db
+                        {:find '[fact]
+                         :where '[[event ::domain/slug id]
+                                  [fact ::belongs-to-event event]]
+                         :args [{'id slug}]})]
+    (vec
+     (for [[eid] results]
+       (let [tx (crux/entity-tx db eid)]
+         (assoc (crux/entity db eid)
+                ::domain/at (:crux.db/valid-time tx)))))))
+
+(defn- fetch [db event-id]
+  (let [eid (ffirst (crux/q db
+                            {:find '[e]
+                             :where '[[e ::domain/slug id]]
+                             :args [{'id event-id}]}))
+        event (assoc (crux/entity db eid)
+                     ::domain/facts (facts db event-id))]
+    (assert (s/valid? ::domain/event event)
+            (s/explain-str ::domain/event event))
+    event))
+
+(defn- add-event-id [event-id doc]
+  (assoc doc ::belongs-to-event event-id))
+
+(defn- persist! [node event-id state]
+  (assert (s/valid? ::domain/event state)
+          (s/explain-str ::domain/event state))
+  (let [event-id (:crux.db/id state)
+        facts (->> (::domain/facts state)
+                   (remove :crux.db/id)
+                   (map (partial add-event-id event-id))
+                   (map maybe-add-crux-id))
+        state-without-facts (dissoc state ::domain/facts)]
+    (crux/submit-tx node (for [doc (cons state-without-facts facts)]
+                           [:crux.tx/put doc]))))
+
+(defn- seed! [node]
+  (let [event (-> (slurp "session.edn")
+                  edn/read-string
+                  maybe-add-crux-id)]
+    (assert (s/valid? ::domain/event event)
+            (s/explain-str ::domain/event event))
+    (crux/submit-tx node [[:crux.tx/put event]])))
+
+(defn- save-seeds! [db]
+  (let [slug (ffirst (crux/q db
+                             {:find '[slug]
+                              :where '[[e ::domain/slug slug]]}))
+        entity (fetch db slug)]
+    (spit "session.edn" (with-out-str (pprint entity)))))
+
+(defn- interpret [crux-event]
+  (let [ops (:crux/tx-ops crux-event)
+        facts (for [[op doc] ops
+                    :when (and (= op :crux.tx/put)
+                               (:spacy.domain/fact doc))]
+                (dissoc doc :crux.db/id))]
+    facts))
+
+(defn- subscribe! [node events]
+  {:pre [(:channel events)]}
+  (crux/listen node
+               {:crux/event-type :crux/indexed-tx, :with-tx-ops? true}
+               (fn [ev]
+                 (let [facts (interpret ev)
+                       ch (:channel events)]
+                   (async/go (doseq [fact facts]
+                               (async/>! ch fact)))))))
+
+(defrecord Crux [node]
+  component/Lifecycle
+  (start [component]
+    (log/debug "Starting")
+    (let [node (crux/start-node {})]
+      (seed! node)
+      (subscribe! node (:events component))
+      (assoc component :node node)))
+
+  (stop [component]
+    (save-seeds! (crux/db node))
+    (.close node)
+    (dissoc component :node))
+
+  data/Events
+  (fetch [component event-id]
+    (fetch (crux/db node) event-id))
+
+  (persist! [component event-id state]
+    (persist! node event-id state)))

--- a/src/spacy/data.clj
+++ b/src/spacy/data.clj
@@ -1,0 +1,5 @@
+(ns spacy.data)
+
+(defprotocol Events
+  (fetch [this event-id])
+  (persist! [this event-id state]))


### PR DESCRIPTION
This patch introduces https://opencrux.com/ as our data store. For now
all data are stored in an in-memory node that's destroyed when we stop
the system. Replacing it with a persistent solution should be a matter
of changing Crux configuration.

The Crux-related code lives in spacy.crux. That includes:

  - a component that controls the lifecycle of a Crux node,
  - logic for storing and retrieving events (i.e. our aggregates),
  - subscription to Crux transactions, translating them into facts,
    and sending to a provided core.async channel.

Every time we persist an event in a Crux node we store it as:

  - a document with all facts removed, and
  - all the new facts that we haven't stored yet.

Crux is responsible for keeping track of time. Each transaction has
:crux.db/valid-time. When we retrieve a fact from Crux we set its
:spacy.domain/at to :crux.db/valid-time of the transaction in which
it was created.

The core.async channel instantiated in spacy.system will now carry facts
as specified in spacy.domain. spacy.app is responsible for translating
them into server-sent events (see spacy.app/interpret-fact).

spacy.app is decoupled from spacy.crux. A protocol in spacy.data defines
an abstract data store that's implemented by spacy.crux.Crux.