### PR TITLE
Add spacy.main and a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Compile frontend assets
+
+FROM node AS faucet
+WORKDIR /app
+ADD package.json ./
+RUN npm install
+ADD faucet.config.js .
+ADD assets assets/
+RUN npm run compile
+
+# Get all backend dependencies
+
+FROM adoptopenjdk:11-jre-hotspot AS lein
+
+RUN useradd -m spacy
+USER spacy
+WORKDIR /home/spacy
+
+RUN curl \
+  https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein \
+  -o lein \
+  && chmod +x lein
+RUN ./lein version
+
+COPY project.clj .
+RUN ./lein deps
+RUN ./lein cp ./classpath
+
+# Build the target image
+
+FROM adoptopenjdk:11-jre-hotspot
+
+RUN useradd -m spacy
+USER spacy
+WORKDIR /home/spacy
+
+COPY --from=lein /home/spacy/.m2 /home/spacy/.m2/
+COPY --from=lein /home/spacy/classpath ./classpath
+COPY --from=faucet /app/resources/public resources/public/
+COPY resources resources/
+COPY src src/
+COPY session.edn .
+
+CMD java -cp $(cat classpath) clojure.main -m spacy.main

--- a/src/spacy/main.clj
+++ b/src/spacy/main.clj
@@ -1,0 +1,6 @@
+(ns spacy.main
+  (:require [com.stuartsierra.component :as component]
+            [spacy.system :as sys]))
+
+(defn -main []
+  (component/start (sys/system)))


### PR DESCRIPTION
Not building an uberjar because:

  - we're not compiling Clojure sources AOT, and
  - this way we can reuse layers that contain Maven dependencies
    and frontend bundles.

We can reuse most of the layers if only assets/* and src/* change.