### PR TITLE
Use our vocabulary more consistently

### DIFF
--- a/src/spacy/data.clj
+++ b/src/spacy/data.clj
@@ -1,5 +1,5 @@
 (ns spacy.data)
 
 (defprotocol Events
-  (fetch [this event-id])
-  (persist! [this event-id state]))
+  (fetch [this slug])
+  (persist! [this event]))


### PR DESCRIPTION
Events are identified by their URL slugs. Each event also gets
a :crux.db/id but it's an internal Crux detail. This patch should
make it more consistent.

Additionally, there's no need for a slug or an ID when persisting
an event. For now we're assuming the DB is seeded with an event that
has both a slug and an ID assigned beforehand.