### PR TITLE
CI touch-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+
+  test:
 
     runs-on: ubuntu-latest
 
@@ -24,5 +25,12 @@ jobs:
       run: lein deps
     - name: Run tests
       run: lein test
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
     - name: Build the Docker image
       run: docker build . -t spacy:$(date +%s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Cache dependencies
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: cache-${{ hashFiles('project.clj') }}
+        restore-keys: |
+          cache-
     - name: Install dependencies
       run: lein deps
     - name: Run tests


### PR DESCRIPTION
Save a bit of time by:

- caching Clojure dependencies between CI runs, and
- building the Docker image in parallel to running tests.