### PR TITLE
Adds schedule-session function to spacy.domain

### DIFF
--- a/test/spacy/domain_test.clj
+++ b/test/spacy/domain_test.clj
@@ -1,0 +1,59 @@
+(ns spacy.domain-test
+  (:require [spacy.domain :as sut]
+            [clojure.test :as t :refer [deftest]]))
+
+(defn- random-uuid []
+  (java.util.UUID/randomUUID))
+
+(defn test-event [& {:keys [next-up scheduled] :or {next-up (random-uuid)
+                                                         scheduled (random-uuid)}}]
+  {:spacy.domain/waiting-queue [#:spacy.domain{:sponsor "joy"
+                                                :session
+                                                #:spacy.domain{:title "Responsive and Accessible"
+                                                             :description "Responsible!"
+                                                             :id next-up}}]
+   :spacy.domain/rooms ["Berlin" "Monheim"]
+   :spacy.domain/times ["10:00 - 11:00" "11:00 - 12:00"]
+   :spacy.domain/schedule [#:spacy.domain{:sponsor "jans"
+                                          :session
+                                          #:spacy.domain{:title "Idris"
+                                                         :description "Ich liebe Typen"
+                                                         :id scheduled}
+                                          :room "Berlin"
+                                          :time "10:00 - 11:00"}]
+   :spacy.domain/facts []
+   :spacy.domain/slug "dezember-2020-strategie-event"})
+
+(deftest test-can-schedule-session?
+  (t/testing "Session with correct session id, room, and time can be scheduled"
+    (t/is (some? (let [sid (random-uuid)]
+                   (sut/can-schedule-session?
+                    (test-event :next-up sid) {:id sid :room "Berlin" :time "11:00 - 12:00"})))))
+  (t/testing "Session to schedule must be the next in line"
+    (t/is (not (let [sid (random-uuid)]
+                 (sut/can-schedule-session?
+                  (test-event :next-up (random-uuid)) {:id sid :room "Berlin" :time "11:00 - 12:00"})))))
+  (t/testing "Session must be for a valid room"
+    (t/is (not (let [sid (random-uuid)]
+                 (sut/can-schedule-session?
+                  (test-event :next-up sid) {:id sid :room "Non-existent room" :time "11:00 - 12:00"})))))
+  (t/testing "Session must be for a valid time"
+    (t/is (not (let [sid (random-uuid)]
+                 (sut/can-schedule-session?
+                  (test-event :next-up sid) {:id sid :room "Berlin" :time "Non-existent time"})))))
+  (t/testing "Session cannot be placed in a slot which is already taken"
+    (t/is (not (let [sid (random-uuid)]
+                 (sut/can-schedule-session?
+                  (test-event :next-up sid) {:id sid :room "Berlin" :time "10:00 - 11:00"}))))))
+
+
+(deftest test-schedule-session
+  (t/testing "Test scheduling of event"
+    (let [sid (random-uuid)
+          event (test-event :next-up sid)
+          new-state (sut/schedule-session event {:id sid :room "Berlin" :time "11:00 - 12:00"})]
+      (t/is (empty? (:spacy.domain/waiting-queue new-state)))
+      (t/is (some   (fn [s] (= (get-in s [:spacy.domain/session :spacy.domain/id]) sid))
+                    (:spacy.domain/schedule new-state)))
+      (t/is (some   (fn [f] (= (:spacy.domain/fact f) :spacy.domain/session-scheduled))
+                    (:spacy.domain/facts new-state))))))


### PR DESCRIPTION
This adds the function schedule-session to the domain which takes the
first element from the queue and places it in the schedule. I also
implemented the logic for determining if a session is actually able to
be positioned in the slot where we want to place (it needs to be the
first in the queue, the slot must be a valid one, and the slot must
not be already taken). I also added some unit tests with a test event
to test can-schedule-session? function. I'm not completely happy with
the tests: I feel like there is an opportunity here to use some generative
tests, which don't all use the same event data object. But writing the
unit a la TDD did help me to write the can-schedule-session? function with
all of its different conditions, so I figure that it is better than nothing.