### PR TITLE
Adds endpoint for schedule-session and actions to trigger it in the UI

### DIFF
--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -51,7 +51,7 @@
                     <th>{{room}}</th>
                     {% for time in times %}
                     <td>
-                        {% for slot in scheduled %}
+                        {% for slot in schedule %}
 
                         {% ifequal room slot.room %}
                         {% ifequal time slot.time %}
@@ -63,6 +63,28 @@
                             {{ slot.session.description }}
                         </details>
 
+                        {% endifequal %}
+                        {% endifequal %}
+
+                        {% endfor %}
+
+
+                        {% for slot in available-slots %}
+
+                        {% ifequal room slot.room %}
+                        {% ifequal time slot.time %}
+                        {% if next-up %}
+                        {% ifequal next-up.sponsor current-user %}
+
+                        <form method="POST" action="{{uris.spacy..app/schedule-session}}">
+                            <input type="hidden" name="id" value="{{next-up.session.id}}">
+                            <input type="hidden" name="room" value="{{room}}">
+                            <input type="hidden" name="time" value="{{time}}">
+                            <button>Choose Slot</button>
+                        </form>
+
+                        {% endifequal %}
+                        {% endif %}
                         {% endifequal %}
                         {% endifequal %}
 

--- a/src/spacy/domain.clj
+++ b/src/spacy/domain.clj
@@ -108,6 +108,12 @@
   (and (is-valid-slot? state room time)
        (not (slot-taken? state room time))))
 
+(defn available-slots [event]
+  (for [time (::times event)
+        room (::rooms event)
+        :when (is-open-slot? event room time)]
+    {:time time :room room}))
+
 (defn can-schedule-session?
   "The slot must be open and the session must be the first in the queue"
   [state {:keys [id room time]}]
@@ -131,6 +137,12 @@
           (update ::waiting-queue rest)
           (update ::schedule conj scheduled-session)
           (update ::facts into new-facts)))))
+
+(defn event->ui-representation [event]
+  (-> event
+      (assoc ::next-up (first (::waiting-queue event)))
+      (assoc ::waiting-queue (rest (::waiting-queue event)))
+      (assoc ::available-slots (available-slots event))))
 
 (comment
   (s/explain


### PR DESCRIPTION
This adds the schedule-session endpoint to the app.

I've pulled the
transformation of the current state into the domain namespace because
for the new available-slots property, I want to use the namespaced
keywords for the calculation (and we strip the namespaces from the keywords
before sending them to the UI).

I also renamed some variables which were called `session` to now be called
`event`, since we are referring to the current state of our event, not to
a specific session which has been suggested/scheduled.

After this change, I noticed some mistakes with the UI implementation
(the UI custom element always adds the new sessions to the queue, even
if the UpNext area is empty). But I will fix that in another MR.

This doesn't implement any UI behavior for session-scheduled yet:
When you schedule a session, this will by default redirect you back to
the main page and reload it.