### PR TITLE
Pulled the event->ui-representation into a event-view-model function

### DIFF
--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -61,18 +61,24 @@
       {:links [{:href (bidi/path-for routes ::event :event-slug "dezember-2020-strategie-event")
                 :text "Strategie Event Open Space 2020"}]}))))
 
+(defn event-view-model [event]
+  (-> event
+      (assoc :session-name "Strategie Event Open Space 2020")
+      (assoc :next-up (first (:spacy.domain/waiting-queue event)))
+      (assoc :waiting-queue (rest (:spacy.domain/waiting-queue event)))
+      (assoc :available-slots (domain/available-slots event))))
+
 (defn show-event [{:keys [data]}]
   (get-resource
    (fn [ctx]
      (let [slug (get-in ctx [:parameters :path :event-slug])
            event (-> (data/fetch data slug)
-                     domain/event->ui-representation
+                     event-view-model
                      drop-namespace-from-keywords)]
        (selmer/render-file
         "templates/event.html"
         (->
          event
-         (assoc :session-name "Strategie Event Open Space 2020")
          (assoc :current-user "joy") ;; TODO - replace with user from header
          (assoc :uris {::sse
                        (bidi/path-for routes ::sse :event-slug slug)

--- a/src/spacy/domain.clj
+++ b/src/spacy/domain.clj
@@ -138,12 +138,6 @@
           (update ::schedule conj scheduled-session)
           (update ::facts into new-facts)))))
 
-(defn event->ui-representation [event]
-  (-> event
-      (assoc ::next-up (first (::waiting-queue event)))
-      (assoc ::waiting-queue (rest (::waiting-queue event)))
-      (assoc ::available-slots (available-slots event))))
-
 (comment
   (s/explain
    ::event


### PR DESCRIPTION
Pulled the event->ui-representation into a event-view-model function

I agree that the event->ui-representation does not really belong in `domain`, so I moved it into a function here in `spacy.app`. I just made sure to add it before the keywords are dropped, so that we can still use the `domain/available-slots` function