### PR TITLE
Restructures HTML in view + adds very limited styling

### DIFF
--- a/assets/components/session/index.js
+++ b/assets/components/session/index.js
@@ -1,0 +1,15 @@
+function sessionTemplate() {
+  return document.getElementById("session-template").content
+    .querySelector("*") // Find first true HTML node which will be our session markup
+    .cloneNode(true);
+}
+
+export function createSession(sponsor, session) {
+  const element = sessionTemplate();
+  element.querySelector("[id]").id = session.id;
+  element.querySelector("[data-slot=title]").textContent = session.title;
+  element.querySelector("[data-slot=sponsor]").textContent = sponsor;
+  element.querySelector("[data-slot=description]").textContent = session.description;
+
+  return element;
+}

--- a/assets/components/session/index.scss
+++ b/assets/components/session/index.scss
@@ -1,10 +1,27 @@
 .session {
+  --post-it-width: 15rem;
   display: inline-block;
   box-shadow: $box-shadow;
   padding: $spacer-sm;
   background-color: $orange-400;
+  max-width: var(--post-it-width);
+  display: flex;
 
   &[open] summary {
     margin-bottom: $spacer-xxs;
+  }
+
+  // Use the last hex digit of the UUID id to randomize the background color
+  &[id$="1"], &[id$="5"],
+  &[id$="9"], &[id$="d"] {
+    background-color: $yellow-400;
+  }
+  &[id$="2"], &[id$="6"],
+  &[id$="a"], &[id$="e"] {
+    background-color: $teal-300;
+  }
+  &[id$="3"], &[id$="7"],
+  &[id$="b"], &[id$="f"] {
+    background-color: var(--background-color, $pink-400);
   }
 }

--- a/assets/components/session/index.scss
+++ b/assets/components/session/index.scss
@@ -1,0 +1,10 @@
+.session {
+  display: inline-block;
+  box-shadow: $box-shadow;
+  padding: $spacer-sm;
+  background-color: $orange-400;
+
+  &[open] summary {
+    margin-bottom: $spacer-xxs;
+  }
+}

--- a/assets/components/up-next/index.scss
+++ b/assets/components/up-next/index.scss
@@ -1,0 +1,9 @@
+up-next {
+  display: block;
+  position: sticky;
+  top: 0;
+  margin: $spacer-xxs 0;
+  padding: $spacer-sm;
+  border: 1px dashed black;
+  background-color: $orange-200;
+}

--- a/assets/components/waiting-queue/element.js
+++ b/assets/components/waiting-queue/element.js
@@ -1,3 +1,5 @@
+import { createSession } from "../session";
+
 export class WaitingQueue extends HTMLElement {
   connectedCallback() {
     if (!this.form || !this.list) {
@@ -23,11 +25,7 @@ export class WaitingQueue extends HTMLElement {
       console.error("Could not find session to add to queue.");
       return;
     }
-    const element = this.newSession();
-    element.querySelector("[id]").id = session.id;
-    element.querySelector("[data-slot=title]").textContent = session.title;
-    element.querySelector("[data-slot=sponsor]").textContent = session.sponsor;
-    element.querySelector("[data-slot=description]").textContent = session.description;
+    const element = createSession(session.sponsor, session);
 
     this.list.appendChild(element);
   }
@@ -41,7 +39,7 @@ export class WaitingQueue extends HTMLElement {
   }
 
   newSession() {
-    return this.querySelector("template").content
+    return document.getElementById("session-template").content
       .querySelector("*") // Find first true HTML node which will be our session markup
       .cloneNode(true);
   }

--- a/assets/components/waiting-queue/index.scss
+++ b/assets/components/waiting-queue/index.scss
@@ -1,0 +1,24 @@
+[lang=en] {
+  --up-next-text: "Up Next:";
+}
+[lang=de] {
+  --up-next-text: "Nächster:";
+}
+
+waiting-queue {
+  ol > li {
+    margin: $spacer-xxs 0;
+
+    &:first-child {
+      padding: $spacer-sm;
+      border: 1px dashed black;
+      margin-bottom: $spacer-xs;
+
+      &::before {
+        content: var(--up-next-text);
+        margin-bottom: $spacer-xs;
+        display: block;
+      }
+    }
+  }
+}

--- a/assets/components/waiting-queue/index.scss
+++ b/assets/components/waiting-queue/index.scss
@@ -13,6 +13,7 @@ waiting-queue {
       padding: $spacer-sm;
       border: 1px dashed black;
       margin-bottom: $spacer-xs;
+      max-width: max-content;
 
       &::before {
         content: var(--up-next-text);

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -5,23 +5,27 @@ body {
   display: grid;
   min-height: 100vh;
   grid-template-rows: min-content 1fr;
+  grid-template-areas:
+    "header"
+    "main";
 }
 
 body > * {
   padding: $spacer-sm;
 }
 
+body h1 {
+  margin: 0 0 $spacer-xs;
+  font-size: 1rem;
+  font-weight: normal;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
 header {
   $space: $spacer-sm;
   background-color: $gray-200;
-
-  h1 {
-    margin: 0 0 $spacer-xs;
-    font-size: 1rem;
-    font-weight: normal;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-  }
+  grid-area: header;
 
   ul {
     list-style: none;
@@ -34,6 +38,20 @@ header {
 }
 
 main {
+  grid-area: main;
+}
+
+main[data-layout="index"] {
+  display: grid;
+  align-self: center;
+  place-items: center;
+
+  ul {
+    padding: 0;
+  }
+}
+
+main[data-layout="event"] {
   display: grid;
   grid-template-areas:
     "up-next"

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -1,0 +1,86 @@
+$breakpoint-phone-landscape-up: 25rem;
+$breakpoint-desktop-up: 60rem;
+
+body {
+  display: grid;
+  min-height: 100vh;
+  grid-template-rows: min-content 1fr;
+}
+
+body > * {
+  padding: $spacer-sm;
+}
+
+header {
+  $space: $spacer-sm;
+  background-color: $gray-200;
+
+  h1 {
+    margin: 0 0 $spacer-xs;
+    font-size: 1rem;
+    font-weight: normal;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(7rem, auto));
+    gap: $spacer-xs;
+  }
+}
+
+main {
+  display: grid;
+  grid-template-areas:
+    "up-next"
+    "bulletin-board"
+    "waiting-queue"
+    "user-notifications";
+
+  up-next {
+    grid-area: up-next;
+  }
+
+  bulletin-board {
+    grid-area: bulletin-board;
+    overflow: auto;
+  }
+
+  waiting-queue {
+    grid-area: waiting-queue;
+  }
+
+  user-notifications {
+    grid-area: user-notifications;
+  }
+
+  #sessions:target {
+    padding-top: $spacer-xl;
+  }
+
+  h2 {
+    margin-top: $spacer-sm;
+    margin-bottom: $spacer-sm;
+  }
+  h2 ~ h2 {
+    margin-top: $spacer-md;
+  }
+
+  @media (min-width: $breakpoint-desktop-up) {
+    grid-template-areas:
+      "up-next bulletin-board"
+      "waiting-queue bulletin-board"
+      "waiting-queue user-notifications";
+    grid-template-columns: 20rem 1fr;
+    grid-template-rows: min-content 1fr min-content;
+    gap: $spacer-base;
+
+    #sessions:target {
+      padding-top: 0;
+    }
+  }
+}

--- a/assets/styles/_utilities.scss
+++ b/assets/styles/_utilities.scss
@@ -1,0 +1,14 @@
+.visually-hidden {
+	position: absolute !important;
+	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+	clip: rect(1px, 1px, 1px, 1px);
+	padding:0 !important;
+	border:0 !important;
+	height: 1px !important;
+	width: 1px !important;
+	overflow: hidden;
+}
+
+.horizontal-scroll {
+  overflow-x: auto;
+}

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -1,9 +1,34 @@
 $font-size-sm: 0.875rem;
+$font-size-base: 1rem;
+$font-sans-serif: -apple-system, 'Open Sans', 'Helvetica Neue', sans-serif;
 
-$spacer-xss: 0.25rem;
+$spacer-xxs: 0.25rem;
 $spacer-xs: 0.5rem;
 $spacer-sm: 0.75rem;
 $spacer-base: 1.25rem;
 $spacer-md: 2rem;
 $spacer-lg: 3.25rem;
 $spacer-xl: 5.25rem;
+
+// Shadows taken from: https://tailwindcss.com/docs/box-shadow
+
+$box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+
+
+// Colors taken from: https://tailwindcss.com/docs/customizing-colors#default-color-palette
+
+$gray-100: #F7FAFC;
+$gray-200: #EDF2F7;
+$gray-800: #2D3748;
+$gray-900: #1A202C;
+
+$green-300: #9AE6B4;
+
+$orange-200: #FEEBC8;
+$orange-400: #F6AD55;
+
+$blue-500: #4299E1;
+$blue-600: #3182CE;
+$blue-700: #2B6CB0;
+
+$indigo-300: #A3BFFA;

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -27,8 +27,15 @@ $green-300: #9AE6B4;
 $orange-200: #FEEBC8;
 $orange-400: #F6AD55;
 
+$yellow-400: #F6E05E;
+
+$teal-300: #81E6D9;
+
+$blue-300: #90CDF4;
 $blue-500: #4299E1;
 $blue-600: #3182CE;
 $blue-700: #2B6CB0;
 
 $indigo-300: #A3BFFA;
+
+$pink-400: #F687B3;

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -1,11 +1,54 @@
 @import "./variables";
+@import "./utilities";
+@import "./layout";
+
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+// RESET
+body, p {
+  margin: 0;
+}
+
+// GLOBAL STYLES
 
 body {
-  font-family: -apple-system, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: $font-sans-serif;
+  color: $gray-800;
 }
 
 body:not(.js) .js-only {
   display: none;
 }
 
+a {
+  color: $blue-700;
+}
+a:hover, a:focus {
+  color: $blue-600;
+}
+
+// INPUT STYLING
+
+label {
+  display: block;
+}
+input, textarea {
+  font-family: $font-sans-serif;
+  font-size: $font-size-base;
+  display: block;
+  padding: $spacer-xs $spacer-sm;
+  border: 1px solid lightgray;
+  width: 100%;
+  margin-top: $spacer-xxs;
+}
+label + label,
+label + button {
+  margin-top: $spacer-xs;
+}
+
+@import "../components/session/";
+@import "../components/up-next/";
 @import "../components/user-notifications/";
+@import "../components/waiting-queue/";

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -9,8 +9,8 @@
 
     <nav>
         <ul>
-            <li><a href="#up-next">Up Next</a></li>
             <li><a href="#sessions">Sessions</a></li>
+            <li><a href="#new-session">Suggest a new session</a></li>
             <li><a href="#queue">Queue</a></li>
             <li class="js-only"><a href="#notifications">Notifications</a></li>
         </ul>
@@ -18,98 +18,89 @@
 </header>
 <main>
     <up-next current-user="{{current-user}}">
-        <h2 id="up-next">Up Next</h2>
-        {% if next-up %}
-
-        <details id="{{next-up.session.id}}">
-            <summary>{{next-up.session.title}} - {{next-up.sponsor}}</summary>
-            {{next-up.session.description}}
-        </details>
-
-        <p role="status">
+        <div data-content-slot>
+            {% if next-up %}
             {% ifequal next-up.sponsor current-user %}
-            You are currently next in line! Please select a slot for your session.
+            <p role="status">
+                You are currently next in line! Please <a href="#sessions">select a slot</a> for your session "{{next-up.session.title}}".
+            </p>
             {% endifequal %}
-        </p>
-
-        {% endif %}
+            {% endif %}
+        </div>
+        <template data-template="up-next">
+            <p role="status">
+                You are currently next in line! Please <a href="#sessions">select a slot</a> for your session "<span data-slot="title"></span>".
+            </p>
+        </template>
     </up-next>
     <bulletin-board>
         <h2 id="sessions">Sessions</h2>
-        <table>
-            <thead>
-                <tr>
-                    <th>Room</th>
-                    {% for time in times %}
-                    <th>{{time}}</th>
-                    {% endfor %}
-                </tr>
-            </thead>
-            <tbody>
-                {% for room in rooms %}
-                <tr>
-                    <th>{{room}}</th>
-                    {% for time in times %}
-                    <td>
-                        {% for slot in schedule %}
-
-                        {% ifequal room slot.room %}
-                        {% ifequal time slot.time %}
-
-                        <details id="{{slot.session.id}}">
-                            <summary>
-                                {{ slot.session.title }} - {{ slot.sponsor }}
-                            </summary>
-                            {{ slot.session.description }}
-                        </details>
-
-                        {% endifequal %}
-                        {% endifequal %}
-
+        <div class="horizontal-scroll">
+            <table>
+                <thead>
+                    <tr>
+                        <th>Room</th>
+                        {% for time in times %}
+                        <th>{{time}}</th>
                         {% endfor %}
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for room in rooms %}
+                    <tr>
+                        <th>{{room}}</th>
+                        {% for time in times %}
+                        <td>
+                            {% for slot in schedule %}
+
+                            {% ifequal room slot.room %}
+                            {% ifequal time slot.time %}
+
+                            <details class="session" id="{{slot.session.id}}">
+                                <summary>
+                                    {{ slot.session.title }} - {{ slot.sponsor }}
+                                </summary>
+                                {{ slot.session.description }}
+                            </details>
+
+                            {% endifequal %}
+                            {% endifequal %}
+
+                            {% endfor %}
 
 
-                        {% for slot in available-slots %}
+                            {% for slot in available-slots %}
 
-                        {% ifequal room slot.room %}
-                        {% ifequal time slot.time %}
-                        {% if next-up %}
-                        {% ifequal next-up.sponsor current-user %}
+                            {% ifequal room slot.room %}
+                            {% ifequal time slot.time %}
+                            {% if next-up %}
+                            {% ifequal next-up.sponsor current-user %}
 
-                        <form method="POST" action="{{uris.spacy..app/schedule-session}}">
-                            <input type="hidden" name="id" value="{{next-up.session.id}}">
-                            <input type="hidden" name="room" value="{{room}}">
-                            <input type="hidden" name="time" value="{{time}}">
-                            <button>Choose Slot</button>
-                        </form>
+                            <form method="POST" action="{{uris.spacy..app/schedule-session}}">
+                                <input type="hidden" name="id" value="{{next-up.session.id}}">
+                                <input type="hidden" name="room" value="{{room}}">
+                                <input type="hidden" name="time" value="{{time}}">
+                                <button>
+                                    Choose Slot <span class="visually-hidden">Room {{room}}, Time {{time}}</span>
+                                </button>
+                            </form>
 
-                        {% endifequal %}
-                        {% endif %}
-                        {% endifequal %}
-                        {% endifequal %}
+                            {% endifequal %}
+                            {% endif %}
+                            {% endifequal %}
+                            {% endifequal %}
 
+                            {% endfor %}
+                        </td>
                         {% endfor %}
-                    </td>
+                    </tr>
                     {% endfor %}
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </tbody>
+            </table>
+        </div>
     </bulletin-board>
     <waiting-queue>
-        <h2 id="queue">Queue</h2>
-        <ol>
-            {% for item in waiting-queue %}
-            <li>
-                <details id="{{item.session.id}}">
-                    <summary>
-                        {{item.session.title}} - {{item.sponsor}}
-                    </summary>
-                    {{item.session.description}}
-                </details>
-            </li>
-            {% endfor %}
-        </ol>
+        <h2 id="new-session">Suggest a new session</h3>
         <hijax-form>
             <form method="POST" action="{{uris.spacy..app/submit-session}}">
                 <label>
@@ -123,20 +114,26 @@
                 <button type="submit">Submit Session</button>
             </form>
         </hijax-form>
-        <template>
+        <h2 id="queue">Queue</h2>
+        <ol>
+            {% for item in waiting-queue %}
             <li>
-                <details id>
+                <details class="session" id="{{item.session.id}}">
                     <summary>
-                        <span data-slot="title"></span> - <span data-slot="sponsor"></span>
+                        {{item.session.title}} - {{item.sponsor}}
                     </summary>
-                    <span data-slot="description"></span>
+                    {{item.session.description}}
                 </details>
             </li>
-        </template>
+            {% endfor %}
+        </ol>
     </waiting-queue>
-    <user-notifications current-user="{{current-user}}" hidden role="log">
+    <user-notifications current-user="{{current-user}}" hidden role="log" aria-live="polite">
         <h2 id="notifications">Notifications</h2>
-        <ul role="log"></ul>
+        <details open>
+            <summary>Toggle Notifications</summary>
+            <ul></ul>
+        </details>
 
         <template data-template="session-suggested">
             <li>
@@ -146,5 +143,16 @@
         </template>
     </user-notifications>
     <fact-handler uri="{{uris.spacy..app/sse}}"></fact-handler>
+
+    <template id="session-template">
+        <li>
+            <details class="session" id>
+                <summary>
+                    <span data-slot="title"></span> - <span data-slot="sponsor"></span>
+                </summary>
+                <span data-slot="description"></span>
+            </details>
+        </li>
+    </template>
 </main>
 {% endblock %}

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -16,7 +16,7 @@
         </ul>
     </nav>
 </header>
-<main>
+<main data-layout="event">
     <up-next current-user="{{current-user}}">
         <div data-content-slot>
             {% if next-up %}

--- a/resources/templates/index.html
+++ b/resources/templates/index.html
@@ -2,7 +2,7 @@
 {% block title %}Open Spaces{% endblock %}
 {% block body %}
 
-<main>
+<main data-layout="index">
     <h1>Open Spaces</h1>
 
     <ul>

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -65,7 +65,6 @@
   (-> event
       (assoc :session-name "Strategie Event Open Space 2020")
       (assoc :next-up (first (:spacy.domain/waiting-queue event)))
-      (assoc :waiting-queue (rest (:spacy.domain/waiting-queue event)))
       (assoc :available-slots (domain/available-slots event))))
 
 (defn show-event [{:keys [data]}]


### PR DESCRIPTION
One main thing: Now the session that is "up-next" is no longer separated
from the other entries in the Queue. It is listed directly in the ol list
in the queue, and the first entry now simply receives a special styling
with CSS.

This also adds a first CSS layout + very lightweight styling:
* make the sessions look like post-ITs (set a max-width, post-IT like colors, & box-shadow)
* basic CSS layout for the page
* add horizontal scrolling container around the table so that it doesn't
expand past the viewport on mobile devices
* very minimal styling for the header + nav links

I originally intended to use named CSS colors for the prototype, but they
just aren't very pretty. Instead, I've taken the colors from Tailwind CSS.

![Screenshot_2020-11-13 Strategie Event Open Space 2020(1)](https://user-images.githubusercontent.com/1502724/99107384-0dd99080-25e6-11eb-9951-ae15bb277fbf.png)

