### PR TITLE
Detach facts from events, add errors

### DIFF
--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -113,10 +113,11 @@
        :response (fn [ctx]
                    (let [slug (get-in ctx [:parameters :path :event-slug])
                          params (get-in ctx [:parameters :form])
-                         state (data/fetch data slug)]
-                     (if-not (domain/can-schedule-session? state params)
+                         state (data/fetch data slug)
+                         outcome (domain/schedule-session state params)]
+                     (if (::domain/error outcome)
                        (reject-request ctx)
-                       (let [outcome (domain/schedule-session state params)]
+                       (do
                          (data/persist! data outcome)
                          (yada-redirect ctx (bidi/path-for routes ::event :event-slug slug))))))}}})))
 

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -99,8 +99,8 @@
                          slug (get-in ctx [:parameters :path :event-slug])
                          params  (get-in ctx [:parameters :form])
                          state (data/fetch data slug)
-                         new-state (domain/suggest-session state current-user params)]
-                     (data/persist! data new-state)
+                         outcome (domain/suggest-session state current-user params)]
+                     (data/persist! data outcome)
                      (yada-redirect ctx (bidi/path-for routes ::event :event-slug slug))))}}})))
 
 (defn schedule-session [{:keys [data events]}]
@@ -116,8 +116,8 @@
                          state (data/fetch data slug)]
                      (if-not (domain/can-schedule-session? state params)
                        (reject-request ctx)
-                       (let [new-state (domain/schedule-session state params)]
-                         (data/persist! data new-state)
+                       (let [outcome (domain/schedule-session state params)]
+                         (data/persist! data outcome)
                          (yada-redirect ctx (bidi/path-for routes ::event :event-slug slug))))))}}})))
 
 (defmulti ^:private interpret-fact ::domain/fact)

--- a/src/spacy/data.clj
+++ b/src/spacy/data.clj
@@ -2,4 +2,4 @@
 
 (defprotocol Events
   (fetch [this slug])
-  (persist! [this event]))
+  (persist! [this outcome]))

--- a/src/spacy/domain.clj
+++ b/src/spacy/domain.clj
@@ -73,7 +73,11 @@
   inst?)
 
 (s/def ::outcome
-  (s/keys :req [::event ::facts]))
+  (s/or :success (s/keys :req [::event ::facts])
+        :failure (s/keys :req [::error])))
+
+(s/def ::error
+  #{::cannot-schedule-session})
 
 (defn- random-uuid []
   (java.util.UUID/randomUUID))
@@ -126,7 +130,7 @@
 (defn schedule-session [state {:keys [id room time] :as data}]
   {:post [(s/valid? ::outcome %)]}
   (if-not (can-schedule-session? state data)
-    state ;; if no session can be scheduled, return state with no modification
+    {::error ::cannot-schedule-session}
     (let [queue (get-in state [::waiting-queue])
           session (first queue)
           fact-id (random-uuid)

--- a/test/spacy/domain_test.clj
+++ b/test/spacy/domain_test.clj
@@ -50,10 +50,11 @@
 (deftest test-schedule-session
   (t/testing "Test scheduling of event"
     (let [sid (random-uuid)
-          event (test-event :next-up sid)
-          new-state (sut/schedule-session event {:id sid :room "Berlin" :time "11:00 - 12:00"})]
-      (t/is (empty? (:spacy.domain/waiting-queue new-state)))
+          outcome (-> (test-event :next-up sid)
+                      (sut/schedule-session {:id sid :room "Berlin" :time "11:00 - 12:00"}))
+          {:spacy.domain/keys [event facts]} outcome]
+      (t/is (empty? (:spacy.domain/waiting-queue event)))
       (t/is (some   (fn [s] (= (get-in s [:spacy.domain/session :spacy.domain/id]) sid))
-                    (:spacy.domain/schedule new-state)))
+                    (:spacy.domain/schedule event)))
       (t/is (some   (fn [f] (= (:spacy.domain/fact f) :spacy.domain/session-scheduled))
-                    (:spacy.domain/facts new-state))))))
+                    facts)))))


### PR DESCRIPTION
Events don't contain facts now. Domain functions that modify events return an _outcome_. Successful outcomes include the new state of the event and a collection of new facts. Both are persisted in Crux. Faulty outcomes come with an error code.
