### PR TITLE
Rename spacy.system/Events to FactsChannels

### DIFF
--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -135,7 +135,7 @@
                 :description description
                 :sponsor sponsor}}))
 
-(defn sse-for-event [{{:keys [mult-channel]} :events :as system}]
+(defn sse-for-event [{{:keys [mult-channel]} :fact-channel}]
   (yada/handler
    (yada/resource
     {:methods

--- a/src/spacy/crux.clj
+++ b/src/spacy/crux.clj
@@ -68,13 +68,13 @@
                 (dissoc doc :crux.db/id))]
     facts))
 
-(defn- subscribe! [node events]
-  {:pre [(:channel events)]}
+(defn- subscribe! [node fact-channel]
+  {:pre [(:channel fact-channel)]}
   (crux/listen node
                {:crux/event-type :crux/indexed-tx, :with-tx-ops? true}
                (fn [ev]
                  (let [facts (interpret ev)
-                       ch (:channel events)]
+                       ch (:channel fact-channel)]
                    (async/go (doseq [fact facts]
                                (async/>! ch fact)))))))
 
@@ -84,7 +84,7 @@
     (log/debug "Starting")
     (let [node (crux/start-node {})]
       (seed! node)
-      (subscribe! node (:events component))
+      (subscribe! node (:fact-channel component))
       (assoc component :node node)))
 
   (stop [component]

--- a/src/spacy/system.clj
+++ b/src/spacy/system.clj
@@ -16,7 +16,7 @@
 (defn new-data []
   (crux/map->Crux {}))
 
-(defrecord Events [channel mult-channel]
+(defrecord FactChannel [channel mult-channel]
   component/Lifecycle
   (start [component]
     (let [ch (async/chan (async/sliding-buffer 300))]
@@ -26,18 +26,18 @@
   (stop  [component]
     (dissoc component :channel :mult)))
 
-(defn new-events []
-  (-> (map->Events {})))
+(defn new-fact-channel []
+  (-> (map->FactChannel {})))
 
 (defn system []
   (component/system-map
-   :events (new-events)
+   :fact-channel (new-fact-channel)
    :data (component/using
            (new-data)
-           [:events])
+           [:fact-channel])
    :app (component/using
          (app/new-app)
-         [:events :data])
+         [:fact-channel :data])
    :resources (new-web-resources :resource-prefix "public/")
    :router  (component/using
              (new-router)


### PR DESCRIPTION
The term "event" is already present in our domain. FactsChannels don't
really roll off the tongue but should at least prevent any ambiguity.

