### PR TITLE
Modifies the UI components to use the namespaced domain facts

### DIFF
--- a/assets/components/fact-handler/element.js
+++ b/assets/components/fact-handler/element.js
@@ -10,7 +10,7 @@ export class FactHandler extends HTMLElement {
 
   handleFact(event) {
     const data = JSON.parse(event.data);
-    const fact = data["spacy.app/fact"];
+    const fact = data["spacy.domain/fact"];
 
     this.dispatchEvent(new CustomEvent(fact, { detail: data, bubbles: true }));
   }

--- a/assets/components/session/index.js
+++ b/assets/components/session/index.js
@@ -6,10 +6,10 @@ function sessionTemplate() {
 
 export function createSession(sponsor, session) {
   const element = sessionTemplate();
-  element.querySelector("[id]").id = session.id;
-  element.querySelector("[data-slot=title]").textContent = session.title;
+  element.querySelector("[id]").id = session["spacy.domain/id"];
+  element.querySelector("[data-slot=title]").textContent = session["spacy.domain/title"];
   element.querySelector("[data-slot=sponsor]").textContent = sponsor;
-  element.querySelector("[data-slot=description]").textContent = session.description;
+  element.querySelector("[data-slot=description]").textContent = session["spacy.domain/description"];
 
   return element;
 }

--- a/assets/components/user-notifications/element.js
+++ b/assets/components/user-notifications/element.js
@@ -5,19 +5,20 @@ export class UserNotifications extends HTMLElement {
     }
     this.hidden = false;
 
-    document.body.addEventListener("session-suggested", this.addNotification.bind(this));
+    document.body.addEventListener("spacy.domain/session-suggested", this.addNotification.bind(this));
   }
 
   addNotification(ev) {
-    const session = ev.detail["spacy.app/session"];
+    const sponsor = ev.detail["spacy.domain/sponsor"];
+    const session = ev.detail["spacy.domain/session"];
     const notification = this.newNotification(ev.type);
 
-    if (!session || session.sponsor !== this.currentUser || !notification) {
+    if (!session || sponsor !== this.currentUser || !notification) {
       return; // Add no notifications for things we don't understand
     }
 
-    notification.querySelector("[data-slot=title]").textContent = session.title;
-    notification.querySelector("[data-slot=at").textContent = new Date().toLocaleString(); // TODO: formatting, use Crux timestamp?
+    notification.querySelector("[data-slot=title]").textContent = session["spacy.domain/title"];
+    notification.querySelector("[data-slot=at").textContent = new Date(); // TODO: use Crux timestamp, but deal with timezones
 
     this.entries.appendChild(notification);
   }
@@ -31,7 +32,7 @@ export class UserNotifications extends HTMLElement {
   }
 
   newNotification(fact) {
-    const template = this.querySelector(`template[data-template=${fact}]`);
+    const template = this.querySelector(`template[data-template="${fact}"]`);
     if (!template) {
       return;
     }

--- a/assets/components/waiting-queue/element.js
+++ b/assets/components/waiting-queue/element.js
@@ -7,7 +7,7 @@ export class WaitingQueue extends HTMLElement {
     }
 
     this.form.addEventListener("submit", this.submitForm.bind(this));
-    document.body.addEventListener("session-suggested", this.addQueuedSession.bind(this));
+    document.body.addEventListener("spacy.domain/session-suggested", this.addQueuedSession.bind(this));
   }
 
   submitForm(ev) {
@@ -20,12 +20,13 @@ export class WaitingQueue extends HTMLElement {
   }
 
   addQueuedSession(ev) {
-    const session = ev.detail["spacy.app/session"];
-    if (!session) {
+    const sponsor = ev.detail["spacy.domain/sponsor"];
+    const session = ev.detail["spacy.domain/session"];
+    if (!sponsor || !session) {
       console.error("Could not find session to add to queue.");
       return;
     }
-    const element = createSession(session.sponsor, session);
+    const element = createSession(sponsor, session);
 
     this.list.appendChild(element);
   }

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -135,7 +135,7 @@
             <ul></ul>
         </details>
 
-        <template data-template="session-suggested">
+        <template data-template="spacy.domain/session-suggested">
             <li>
                 Your session "<span data-slot="title"></span>" was received and placed in the queue
                 <div data-slot="at"></div>


### PR DESCRIPTION
The UI components now expect facts in exactly the format defined by our domain class. This means that I removed the `interpret-fact` function (we could always
add it in again later, if it proves necessary).