### PR TITLE
Enqueue suggested sessions at the end

### DIFF
--- a/src/spacy/domain.clj
+++ b/src/spacy/domain.clj
@@ -97,7 +97,7 @@
                           ::id fact-id)]]
     {::facts new-facts
      ::event (-> state
-                 (update ::waiting-queue conj new-session))}))
+                 (update ::waiting-queue #(conj (vec %) new-session)))}))
 
 (defn is-first-in-queue? [state id]
   (let [next-up (first (get-in state [::waiting-queue]))]

--- a/test/spacy/domain_test.clj
+++ b/test/spacy/domain_test.clj
@@ -58,3 +58,22 @@
                     (:spacy.domain/schedule event)))
       (t/is (some   (fn [f] (= (:spacy.domain/fact f) :spacy.domain/session-scheduled))
                     facts)))))
+
+(deftest test-waiting-queue
+  (t/testing "Interleaving suggest and schedule actions"
+    (let [sid (random-uuid)
+          event (-> (test-event :next-up sid)
+                    (sut/suggest-session "sponsor" {:title "one", :description ""})
+                    :spacy.domain/event
+                    (sut/schedule-session {:id sid :room "Berlin" :time "11:00 - 12:00"})
+                    :spacy.domain/event
+                    (sut/suggest-session "sponsor" {:title "two", :description ""})
+                    :spacy.domain/event
+                    (sut/suggest-session "sponsor" {:title "three", :description ""})
+                    :spacy.domain/event)
+          waiting-queued-titles (->> event
+                                     :spacy.domain/waiting-queue
+                                     (map (comp :spacy.domain/title
+                                                :spacy.domain/session)))]
+      (t/is (= ["one" "two" "three"]
+               waiting-queued-titles)))))


### PR DESCRIPTION
This fixes a bug caused by adding sessions to a seq using conj.
It resulted in having them at the beginning of the waiting queue.