### PR TITLE
Listen and react to spacy.domain/session-scheduled event in the UI

### DIFF
--- a/assets/components/bulletin-board/element.js
+++ b/assets/components/bulletin-board/element.js
@@ -1,0 +1,30 @@
+import { replaceNode } from "uitil/dom";
+
+export class BulletinBoard extends HTMLElement {
+  connectedCallback() {
+    document.body.addEventListener("spacy.domain/session-scheduled", this.addScheduledSession.bind(this));
+  }
+
+  addScheduledSession() {
+    if (this.hinclude) {
+      this.hinclude.refresh();
+      return;
+    }
+
+    replaceNode(this.schedule, this.newHInclude());
+  }
+
+  get schedule() {
+    return this.querySelector(".schedule");
+  }
+
+  get hinclude() {
+    return this.querySelector("h-include");
+  }
+
+  newHInclude() {
+    return this.querySelector("template").content
+      .querySelector("*") // Find first true HTML node which will be our session markup
+      .cloneNode(true);
+  }
+}

--- a/assets/components/bulletin-board/index.js
+++ b/assets/components/bulletin-board/index.js
@@ -1,0 +1,3 @@
+import { BulletinBoard } from "./element";
+
+customElements.define("bulletin-board", BulletinBoard);

--- a/assets/components/hijax-form/element.js
+++ b/assets/components/hijax-form/element.js
@@ -1,0 +1,30 @@
+import HijaxFormInternal from "hijax-form/form";
+
+/*
+The internal HijaxForm custom element prepares the form to be able to
+be submitted as an ajax request, but does not actually perform the submitting
+of the form. For our applicatin, we want to do both because our form submitting
+should always do the same thing: maybe log an error, but otherwise ignore the
+response which is returned because we are waiting for the SSE events which will
+come from the server.
+*/
+export class HijaxForm extends HijaxFormInternal {
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.form.addEventListener("submit", this.submitForm.bind(this));
+  }
+
+  submitForm(ev) {
+    this.submit()
+      .then(response => {
+        console.log(response.text())
+      });
+
+    ev.preventDefault();
+  }
+
+  get form() {
+    return this.querySelector("form");
+  }
+}

--- a/assets/components/hijax-form/index.js
+++ b/assets/components/hijax-form/index.js
@@ -1,0 +1,3 @@
+import { HijaxForm } from "./element";
+
+customElements.define("hijax-form", HijaxForm);

--- a/assets/components/session/index.js
+++ b/assets/components/session/index.js
@@ -6,7 +6,7 @@ function sessionTemplate() {
 
 export function createSession(sponsor, session) {
   const element = sessionTemplate();
-  element.querySelector("[id]").id = session["spacy.domain/id"];
+  element.querySelector("[data-id]").setAttribute("data-id", session["spacy.domain/id"]);
   element.querySelector("[data-slot=title]").textContent = session["spacy.domain/title"];
   element.querySelector("[data-slot=sponsor]").textContent = sponsor;
   element.querySelector("[data-slot=description]").textContent = session["spacy.domain/description"];

--- a/assets/components/user-notifications/element.js
+++ b/assets/components/user-notifications/element.js
@@ -1,3 +1,11 @@
+function fillTemplate(template, slot, content) {
+  const element = template.querySelector(`[data-slot="${slot}"]`)
+  if (!element) {
+    return;
+  }
+  element.textContent = content;
+}
+
 export class UserNotifications extends HTMLElement {
   connectedCallback() {
     if (!this.entries) {
@@ -6,6 +14,7 @@ export class UserNotifications extends HTMLElement {
     this.hidden = false;
 
     document.body.addEventListener("spacy.domain/session-suggested", this.addNotification.bind(this));
+    document.body.addEventListener("spacy.domain/session-scheduled", this.addNotification.bind(this));
   }
 
   addNotification(ev) {
@@ -13,12 +22,15 @@ export class UserNotifications extends HTMLElement {
     const session = ev.detail["spacy.domain/session"];
     const notification = this.newNotification(ev.type);
 
-    if (!session || sponsor !== this.currentUser || !notification) {
+    if (!session || !this.notifyFor(ev.type, sponsor) || !notification) {
       return; // Add no notifications for things we don't understand
     }
 
-    notification.querySelector("[data-slot=title]").textContent = session["spacy.domain/title"];
-    notification.querySelector("[data-slot=at").textContent = new Date(); // TODO: use Crux timestamp, but deal with timezones
+    fillTemplate(notification, "title", session["spacy.domain/title"]);
+    fillTemplate(notification, "sponsor", sponsor);
+    fillTemplate(notification, "at", new Date()); // TODO: use Crux timestamp, but deal with timezones
+    fillTemplate(notification, "room", ev.detail["spacy.domain/room"]);
+    fillTemplate(notification, "time", ev.detail["spacy.domain/time"]);
 
     this.entries.appendChild(notification);
   }
@@ -29,6 +41,15 @@ export class UserNotifications extends HTMLElement {
 
   get currentUser() {
     return this.getAttribute("current-user");
+  }
+
+  notifyFor(fact, sponsor) {
+    switch (fact) {
+      case "spacy.domain/session-scheduled":
+        return true;
+      default:
+        return sponsor === this.currentUser;
+    }
   }
 
   newNotification(fact) {

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -1,5 +1,7 @@
-import "hijax-form";
+import "h-include/lib/h-include";
 
+import "../components/hijax-form";
+import "../components/bulletin-board";
 import "../components/user-notifications";
 import "../components/fact-handler";
 import "../components/waiting-queue";

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -56,8 +56,8 @@ main[data-layout="event"] {
   grid-template-areas:
     "up-next"
     "bulletin-board"
-    "waiting-queue"
-    "user-notifications";
+    "new-session"
+    "waiting-queue";
 
   up-next {
     grid-area: up-next;
@@ -68,12 +68,12 @@ main[data-layout="event"] {
     overflow: auto;
   }
 
-  waiting-queue {
-    grid-area: waiting-queue;
+  new-session {
+    grid-area: new-session;
   }
 
-  user-notifications {
-    grid-area: user-notifications;
+  waiting-queue {
+    grid-area: waiting-queue;
   }
 
   #sessions:target {
@@ -91,10 +91,10 @@ main[data-layout="event"] {
   @media (min-width: $breakpoint-desktop-up) {
     grid-template-areas:
       "up-next bulletin-board"
-      "waiting-queue bulletin-board"
-      "waiting-queue user-notifications";
+      "new-session bulletin-board"
+      "waiting-queue bulletin-board";
     grid-template-columns: 20rem 1fr;
-    grid-template-rows: min-content 1fr min-content;
+    grid-template-rows: min-content min-content 1fr;
     gap: $spacer-base;
 
     #sessions:target {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,6 +1426,11 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "h-include": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/h-include/-/h-include-4.3.0.tgz",
+      "integrity": "sha512-rTzyp3JNkxdF5qVE9HaBnosqu7jDY+e4ainAyaAfp5wUVtgVjP57PJzso+VITFxLU0gBVRL/qMdLyT/LsVmqRw=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "faucet-pipeline-sass": "^1.4.0"
   },
   "dependencies": {
-    "hijax-form": "^1.1.0"
+    "h-include": "^4.3.0",
+    "hijax-form": "^1.1.0",
+    "uitil": "^2.7.1"
   }
 }

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -12,7 +12,7 @@
             <li><a href="#sessions">Sessions</a></li>
             <li><a href="#new-session">Suggest a new session</a></li>
             <li><a href="#queue">Queue</a></li>
-            <li class="js-only"><a href="#notifications">Notifications</a></li>
+            <li class="js-only visually-hidden"><a href="#notifications">Notifications</a></li>
         </ul>
     </nav>
 </header>
@@ -35,71 +35,78 @@
     </up-next>
     <bulletin-board>
         <h2 id="sessions">Sessions</h2>
-        <div class="horizontal-scroll">
-            <table>
-                <thead>
-                    <tr>
-                        <th>Room</th>
-                        {% for time in times %}
-                        <th>{{time}}</th>
-                        {% endfor %}
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for room in rooms %}
-                    <tr>
-                        <th>{{room}}</th>
-                        {% for time in times %}
-                        <td>
-                            {% for slot in schedule %}
-
-                            {% ifequal room slot.room %}
-                            {% ifequal time slot.time %}
-
-                            <details class="session" id="{{slot.session.id}}">
-                                <summary>
-                                    {{ slot.session.title }} - {{ slot.sponsor }}
-                                </summary>
-                                {{ slot.session.description }}
-                            </details>
-
-                            {% endifequal %}
-                            {% endifequal %}
-
+        <div class="schedule">
+            <div class="horizontal-scroll">
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            {% for room in rooms %}
+                            <th>{{room}}</th>
                             {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for time in times %}
+                        <tr data-time="{{time}}">
+                            <th>{{time}}</th>
+                            {% for room in rooms %}
+                            <td data-time="{{time}}" data-room="{{room}}">
+                                {% for slot in schedule %}
+
+                                {% ifequal time slot.time %}
+                                {% ifequal room slot.room %}
+
+                                <details class="session" data-id="{{slot.session.id}}">
+                                    <summary>
+                                        {{ slot.session.title }} - {{ slot.sponsor }}
+                                    </summary>
+                                    {{ slot.session.description }}
+                                </details>
+
+                                {% endifequal %}
+                                {% endifequal %}
+
+                                {% endfor %}
 
 
-                            {% for slot in available-slots %}
+                                {% for slot in available-slots %}
 
-                            {% ifequal room slot.room %}
-                            {% ifequal time slot.time %}
-                            {% if next-up %}
-                            {% ifequal next-up.sponsor current-user %}
+                                {% ifequal room slot.room %}
+                                {% ifequal time slot.time %}
+                                {% if next-up %}
+                                {% ifequal next-up.sponsor current-user %}
 
-                            <form method="POST" action="{{uris.spacy..app/schedule-session}}">
-                                <input type="hidden" name="id" value="{{next-up.session.id}}">
-                                <input type="hidden" name="room" value="{{room}}">
-                                <input type="hidden" name="time" value="{{time}}">
-                                <button>
-                                    Choose Slot <span class="visually-hidden">Room {{room}}, Time {{time}}</span>
-                                </button>
-                            </form>
+                                <hijax-form>
+                                    <form method="POST" action="{{uris.spacy..app/schedule-session}}">
+                                        <input type="hidden" name="id" value="{{next-up.session.id}}">
+                                        <input type="hidden" name="room" value="{{room}}">
+                                        <input type="hidden" name="time" value="{{time}}">
+                                        <button>
+                                            Choose Slot <span class="visually-hidden">Room {{room}}, Time {{time}}</span>
+                                        </button>
+                                    </form>
+                                </hijax-form>
 
-                            {% endifequal %}
-                            {% endif %}
-                            {% endifequal %}
-                            {% endifequal %}
+                                {% endifequal %}
+                                {% endif %}
+                                {% endifequal %}
+                                {% endifequal %}
 
+                                {% endfor %}
+                            </td>
                             {% endfor %}
-                        </td>
+                        </tr>
                         {% endfor %}
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </tbody>
+                </table>
+            </div>
         </div>
+        <template>
+            <h-include src="{{uris.spacy..app/event}}" fragment="bulletin-board .schedule"></h-include>
+        </template>
     </bulletin-board>
-    <waiting-queue>
+    <new-session>
         <h2 id="new-session">Suggest a new session</h3>
         <hijax-form>
             <form method="POST" action="{{uris.spacy..app/submit-session}}">
@@ -114,11 +121,13 @@
                 <button type="submit">Submit Session</button>
             </form>
         </hijax-form>
+    </new-session>
+    <waiting-queue>
         <h2 id="queue">Queue</h2>
         <ol>
             {% for item in waiting-queue %}
             <li>
-                <details class="session" id="{{item.session.id}}">
+                <details class="session" data-id="{{item.session.id}}">
                     <summary>
                         {{item.session.title}} - {{item.sponsor}}
                     </summary>
@@ -128,7 +137,7 @@
             {% endfor %}
         </ol>
     </waiting-queue>
-    <user-notifications current-user="{{current-user}}" hidden role="log" aria-live="polite">
+    <user-notifications class="visually-hidden" current-user="{{current-user}}" hidden role="log" aria-live="polite">
         <h2 id="notifications">Notifications</h2>
         <details open>
             <summary>Toggle Notifications</summary>
@@ -141,12 +150,18 @@
                 <div data-slot="at"></div>
             </li>
         </template>
+        <template data-template="spacy.domain/session-scheduled">
+            <li>
+                The session "<span data-slot="title"></span>" from <span data-slot="sponsor"></span> has been scheduled at <span data-slot="time"></span> in
+                <span data-slot="room"></span>
+            </li>
+        </template>
     </user-notifications>
     <fact-handler uri="{{uris.spacy..app/sse}}"></fact-handler>
 
     <template id="session-template">
         <li>
-            <details class="session" id>
+            <details class="session" data-id>
                 <summary>
                     <span data-slot="title"></span> - <span data-slot="sponsor"></span>
                 </summary>

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -54,7 +54,9 @@
         (->
          event
          (assoc :current-user "joy") ;; TODO - replace with user from header
-         (assoc :uris {::sse
+         (assoc :uris {::event
+                       (bidi/path-for routes ::event :event-slug slug)
+                       ::sse
                        (bidi/path-for routes ::sse :event-slug slug)
                        ::submit-session
                        (bidi/path-for routes ::submit-session :event-slug slug)


### PR DESCRIPTION
The components to the following:

* bulletin-board (our session schedule) uses transclusion with the h-include
  component to reload the whole contents of the schedule whenever the
  session-scheduled event occurs: this is the simplest implementation, and I
  did it this way because every cell needs to be updated to show the new
  "Choose Slot" buttons for the new session which needs to be scheduled
* waiting-queue deletes the scheduled session from its list and thereby moves
  the next session up in the queue
* user-notifications adds a notification to let screenreader users know which
  session has been scheduled.

Additionally:

* I also switched the order of times and rooms in the table because for the
responsive behavior that I dream of in the future I would prefer to group
the data by time as opposed to room. This could be subject to change though,
because I could change my mind... 😬