### PR TITLE
Up next status

### DIFF
--- a/assets/components/bulletin-board/element.js
+++ b/assets/components/bulletin-board/element.js
@@ -1,0 +1,30 @@
+import { replaceNode } from "uitil/dom";
+
+export class BulletinBoard extends HTMLElement {
+  connectedCallback() {
+    document.body.addEventListener("spacy.domain/session-scheduled", this.addScheduledSession.bind(this));
+  }
+
+  addScheduledSession() {
+    if (this.hinclude) {
+      this.hinclude.refresh();
+      return;
+    }
+
+    replaceNode(this.schedule, this.newHInclude());
+  }
+
+  get schedule() {
+    return this.querySelector(".schedule");
+  }
+
+  get hinclude() {
+    return this.querySelector("h-include");
+  }
+
+  newHInclude() {
+    return this.querySelector("template").content
+      .querySelector("*") // Find first true HTML node which will be our session markup
+      .cloneNode(true);
+  }
+}

--- a/assets/components/bulletin-board/element.js
+++ b/assets/components/bulletin-board/element.js
@@ -2,10 +2,11 @@ import { replaceNode } from "uitil/dom";
 
 export class BulletinBoard extends HTMLElement {
   connectedCallback() {
-    document.body.addEventListener("spacy.domain/session-scheduled", this.addScheduledSession.bind(this));
+    document.body.addEventListener("spacy.domain/session-scheduled", this.reloadBoard.bind(this));
+    document.body.addEventListener("spacy.ui/up-next", this.reloadBoard.bind(this));
   }
 
-  addScheduledSession() {
+  reloadBoard() {
     if (this.hinclude) {
       this.hinclude.refresh();
       return;

--- a/assets/components/bulletin-board/index.js
+++ b/assets/components/bulletin-board/index.js
@@ -1,0 +1,3 @@
+import { BulletinBoard } from "./element";
+
+customElements.define("bulletin-board", BulletinBoard);

--- a/assets/components/hijax-form/element.js
+++ b/assets/components/hijax-form/element.js
@@ -1,0 +1,30 @@
+import HijaxFormInternal from "hijax-form/form";
+
+/*
+The internal HijaxForm custom element prepares the form to be able to
+be submitted as an ajax request, but does not actually perform the submitting
+of the form. For our applicatin, we want to do both because our form submitting
+should always do the same thing: maybe log an error, but otherwise ignore the
+response which is returned because we are waiting for the SSE events which will
+come from the server.
+*/
+export class HijaxForm extends HijaxFormInternal {
+  connectedCallback() {
+    super.connectedCallback();
+
+    this.form.addEventListener("submit", this.submitForm.bind(this));
+  }
+
+  submitForm(ev) {
+    this.submit()
+      .then(response => {
+        console.log(response.text())
+      });
+
+    ev.preventDefault();
+  }
+
+  get form() {
+    return this.querySelector("form");
+  }
+}

--- a/assets/components/hijax-form/index.js
+++ b/assets/components/hijax-form/index.js
@@ -1,0 +1,3 @@
+import { HijaxForm } from "./element";
+
+customElements.define("hijax-form", HijaxForm);

--- a/assets/components/session/index.js
+++ b/assets/components/session/index.js
@@ -6,7 +6,7 @@ function sessionTemplate() {
 
 export function createSession(sponsor, session) {
   const element = sessionTemplate();
-  element.querySelector("[id]").id = session["spacy.domain/id"];
+  element.querySelector("[data-id]").setAttribute("data-id", session["spacy.domain/id"]);
   element.querySelector("[data-slot=title]").textContent = session["spacy.domain/title"];
   element.querySelector("[data-slot=sponsor]").textContent = sponsor;
   element.querySelector("[data-slot=description]").textContent = session["spacy.domain/description"];

--- a/assets/components/session/index.js
+++ b/assets/components/session/index.js
@@ -13,3 +13,14 @@ export function createSession(sponsor, session) {
 
   return element;
 }
+
+export function extractSession(element) {
+  return {
+    "spacy.domain/sponsor": element.querySelector("[data-slot=sponsor]")?.textContent,
+    "spacy.domain/session": {
+      "spacy.domain/id": element.querySelector("[data-id]")?.getAttribute("data-id"),
+      "spacy.domain/title": element.querySelector("[data-slot=title]")?.textContent,
+      "spacy.domain/description": element.querySelector("[data-slot=description]")?.textContent
+    }
+  }
+}

--- a/assets/components/up-next/element.js
+++ b/assets/components/up-next/element.js
@@ -1,0 +1,48 @@
+import { fillTemplate } from "../util/template";
+
+export class UpNext extends HTMLElement {
+  connectedCallback() {
+    document.body.addEventListener("spacy.ui/up-next", this.updateStatus.bind(this));
+  }
+
+  updateStatus(ev) {
+    if (typeof ev.detail === 'string') {
+      this.swapContent(this.statusMessage(ev.detail));
+      this.setAttribute("up-next", "false");
+      return;
+    }
+
+    const sponsor = ev.detail["spacy.domain/sponsor"];
+    const session = ev.detail["spacy.domain/session"];
+
+    const upNext = sponsor === this.currentUser;
+    const status = upNext ? "spacy.ui/up-next" : "spacy.ui/please-wait";
+
+    const template = this.statusMessage(status);
+    fillTemplate(template, "title", session && session["spacy.domain/title"]);
+
+    this.swapContent(template);
+    this.setAttribute("up-next", upNext);
+  }
+
+  swapContent(content) {
+    this.statusElement.innerHTML = "";
+    this.statusElement.appendChild(content);
+  }
+
+  get statusElement() {
+    return this.querySelector("[role=status]");
+  }
+
+  get currentUser() {
+    return this.getAttribute("current-user");
+  }
+
+  statusMessage(status) {
+    const template = this.querySelector(`template[data-template="${status}"]`);
+    if (!template) {
+      return;
+    }
+    return template.content.cloneNode(true);
+  }
+}

--- a/assets/components/up-next/index.js
+++ b/assets/components/up-next/index.js
@@ -1,0 +1,3 @@
+import { UpNext } from "./element";
+
+customElements.define("up-next", UpNext);

--- a/assets/components/up-next/index.scss
+++ b/assets/components/up-next/index.scss
@@ -1,9 +1,14 @@
 up-next {
-  display: block;
-  position: sticky;
-  top: 0;
+  display: flex;
   margin: $spacer-xxs 0;
   padding: $spacer-sm;
-  border: 1px dashed black;
-  background-color: $orange-200;
+  border: 1px dashed $gray-700;
+  background-color: $gray-200;
+  align-items: center;
+
+  &[up-next=true] {
+    position: sticky;
+    top: 0;
+    background-color: $orange-200;
+  }
 }

--- a/assets/components/user-notifications/element.js
+++ b/assets/components/user-notifications/element.js
@@ -1,3 +1,11 @@
+function fillTemplate(template, slot, content) {
+  const element = template.querySelector(`[data-slot="${slot}"]`)
+  if (!element) {
+    return;
+  }
+  element.textContent = content;
+}
+
 export class UserNotifications extends HTMLElement {
   connectedCallback() {
     if (!this.entries) {
@@ -6,6 +14,7 @@ export class UserNotifications extends HTMLElement {
     this.hidden = false;
 
     document.body.addEventListener("spacy.domain/session-suggested", this.addNotification.bind(this));
+    document.body.addEventListener("spacy.domain/session-scheduled", this.addNotification.bind(this));
   }
 
   addNotification(ev) {
@@ -13,12 +22,15 @@ export class UserNotifications extends HTMLElement {
     const session = ev.detail["spacy.domain/session"];
     const notification = this.newNotification(ev.type);
 
-    if (!session || sponsor !== this.currentUser || !notification) {
+    if (!session || !this.notifyFor(ev.type, sponsor) || !notification) {
       return; // Add no notifications for things we don't understand
     }
 
-    notification.querySelector("[data-slot=title]").textContent = session["spacy.domain/title"];
-    notification.querySelector("[data-slot=at").textContent = new Date(); // TODO: use Crux timestamp, but deal with timezones
+    fillTemplate(notification, "title", session["spacy.domain/title"]);
+    fillTemplate(notification, "sponsor", sponsor);
+    fillTemplate(notification, "at", new Date()); // TODO: use Crux timestamp, but deal with timezones
+    fillTemplate(notification, "room", ev.detail["spacy.domain/room"]);
+    fillTemplate(notification, "time", ev.detail["spacy.domain/time"]);
 
     this.entries.appendChild(notification);
   }
@@ -29,6 +41,15 @@ export class UserNotifications extends HTMLElement {
 
   get currentUser() {
     return this.getAttribute("current-user");
+  }
+
+  notifyFor(fact, sponsor) {
+    switch (fact) {
+      case "spacy.domain/session-scheduled":
+        return true;
+      default:
+        return sponsor === this.currentUser;
+    }
   }
 
   newNotification(fact) {

--- a/assets/components/user-notifications/element.js
+++ b/assets/components/user-notifications/element.js
@@ -1,10 +1,4 @@
-function fillTemplate(template, slot, content) {
-  const element = template.querySelector(`[data-slot="${slot}"]`)
-  if (!element) {
-    return;
-  }
-  element.textContent = content;
-}
+import { fillTemplate } from "../util/template";
 
 export class UserNotifications extends HTMLElement {
   connectedCallback() {

--- a/assets/components/util/template.js
+++ b/assets/components/util/template.js
@@ -1,0 +1,7 @@
+export function fillTemplate(template, slot, content) {
+  const element = template.querySelector(`[data-slot="${slot}"]`)
+  if (!element) {
+    return;
+  }
+  element.textContent = content;
+}

--- a/assets/components/waiting-queue/element.js
+++ b/assets/components/waiting-queue/element.js
@@ -1,4 +1,4 @@
-import { createSession } from "../session";
+import { createSession, extractSession } from "../session";
 import { removeNode } from "uitil/dom";
 
 export class WaitingQueue extends HTMLElement {
@@ -21,6 +21,10 @@ export class WaitingQueue extends HTMLElement {
     const element = createSession(sponsor, session);
 
     this.list.appendChild(element);
+
+    if (this.list.children.length === 1) {
+      this.fireUpNextEvent(ev.detail);
+    }
   }
 
   removedQueuedSession(ev) {
@@ -32,6 +36,12 @@ export class WaitingQueue extends HTMLElement {
     }
 
     removeNode(entryInList);
+
+    this.fireUpNextEvent(this.list.children.length ? extractSession(this.list.children[0]) : "spacy.ui/nobody-in-queue");
+  }
+
+  fireUpNextEvent(detail) {
+    this.dispatchEvent(new CustomEvent("spacy.ui/up-next", { detail, bubbles: true }));
   }
 
   get list() {

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -1,5 +1,7 @@
-import "hijax-form";
+import "h-include/lib/h-include";
 
+import "../components/hijax-form";
+import "../components/bulletin-board";
 import "../components/user-notifications";
 import "../components/fact-handler";
 import "../components/waiting-queue";

--- a/assets/scripts/index.js
+++ b/assets/scripts/index.js
@@ -2,8 +2,9 @@ import "h-include/lib/h-include";
 
 import "../components/hijax-form";
 import "../components/bulletin-board";
+import "../components/up-next";
 import "../components/user-notifications";
-import "../components/fact-handler";
 import "../components/waiting-queue";
+import "../components/fact-handler";
 
 document.body.classList.add("js");

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -56,8 +56,8 @@ main[data-layout="event"] {
   grid-template-areas:
     "up-next"
     "bulletin-board"
-    "waiting-queue"
-    "user-notifications";
+    "new-session"
+    "waiting-queue";
 
   up-next {
     grid-area: up-next;
@@ -68,12 +68,12 @@ main[data-layout="event"] {
     overflow: auto;
   }
 
-  waiting-queue {
-    grid-area: waiting-queue;
+  new-session {
+    grid-area: new-session;
   }
 
-  user-notifications {
-    grid-area: user-notifications;
+  waiting-queue {
+    grid-area: waiting-queue;
   }
 
   #sessions:target {
@@ -91,10 +91,10 @@ main[data-layout="event"] {
   @media (min-width: $breakpoint-desktop-up) {
     grid-template-areas:
       "up-next bulletin-board"
-      "waiting-queue bulletin-board"
-      "waiting-queue user-notifications";
+      "new-session bulletin-board"
+      "waiting-queue bulletin-board";
     grid-template-columns: 20rem 1fr;
-    grid-template-rows: min-content 1fr min-content;
+    grid-template-rows: min-content min-content 1fr;
     gap: $spacer-base;
 
     #sessions:target {

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -55,8 +55,8 @@ main[data-layout="event"] {
   display: grid;
   grid-template-areas:
     "up-next"
-    "bulletin-board"
     "new-session"
+    "bulletin-board"
     "waiting-queue";
 
   up-next {

--- a/assets/styles/_variables.scss
+++ b/assets/styles/_variables.scss
@@ -19,6 +19,7 @@ $box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0
 
 $gray-100: #F7FAFC;
 $gray-200: #EDF2F7;
+$gray-700: #4a5568;
 $gray-800: #2D3748;
 $gray-900: #1A202C;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,6 +1426,11 @@
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
       "dev": true
     },
+    "h-include": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/h-include/-/h-include-4.3.0.tgz",
+      "integrity": "sha512-rTzyp3JNkxdF5qVE9HaBnosqu7jDY+e4ainAyaAfp5wUVtgVjP57PJzso+VITFxLU0gBVRL/qMdLyT/LsVmqRw=="
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "faucet-pipeline-sass": "^1.4.0"
   },
   "dependencies": {
-    "hijax-form": "^1.1.0"
+    "h-include": "^4.3.0",
+    "hijax-form": "^1.1.0",
+    "uitil": "^2.7.1"
   }
 }

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -12,7 +12,7 @@
             <li><a href="#sessions">Sessions</a></li>
             <li><a href="#new-session">Suggest a new session</a></li>
             <li><a href="#queue">Queue</a></li>
-            <li class="js-only"><a href="#notifications">Notifications</a></li>
+            <li class="js-only visually-hidden"><a href="#notifications">Notifications</a></li>
         </ul>
     </nav>
 </header>
@@ -35,71 +35,78 @@
     </up-next>
     <bulletin-board>
         <h2 id="sessions">Sessions</h2>
-        <div class="horizontal-scroll">
-            <table>
-                <thead>
-                    <tr>
-                        <th>Room</th>
-                        {% for time in times %}
-                        <th>{{time}}</th>
-                        {% endfor %}
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for room in rooms %}
-                    <tr>
-                        <th>{{room}}</th>
-                        {% for time in times %}
-                        <td>
-                            {% for slot in schedule %}
-
-                            {% ifequal room slot.room %}
-                            {% ifequal time slot.time %}
-
-                            <details class="session" id="{{slot.session.id}}">
-                                <summary>
-                                    {{ slot.session.title }} - {{ slot.sponsor }}
-                                </summary>
-                                {{ slot.session.description }}
-                            </details>
-
-                            {% endifequal %}
-                            {% endifequal %}
-
+        <div class="schedule">
+            <div class="horizontal-scroll">
+                <table>
+                    <thead>
+                        <tr>
+                            <th></th>
+                            {% for room in rooms %}
+                            <th>{{room}}</th>
                             {% endfor %}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for time in times %}
+                        <tr data-time="{{time}}">
+                            <th>{{time}}</th>
+                            {% for room in rooms %}
+                            <td data-time="{{time}}" data-room="{{room}}">
+                                {% for slot in schedule %}
+
+                                {% ifequal time slot.time %}
+                                {% ifequal room slot.room %}
+
+                                <details class="session" data-id="{{slot.session.id}}">
+                                    <summary>
+                                        {{ slot.session.title }} - {{ slot.sponsor }}
+                                    </summary>
+                                    {{ slot.session.description }}
+                                </details>
+
+                                {% endifequal %}
+                                {% endifequal %}
+
+                                {% endfor %}
 
 
-                            {% for slot in available-slots %}
+                                {% for slot in available-slots %}
 
-                            {% ifequal room slot.room %}
-                            {% ifequal time slot.time %}
-                            {% if next-up %}
-                            {% ifequal next-up.sponsor current-user %}
+                                {% ifequal room slot.room %}
+                                {% ifequal time slot.time %}
+                                {% if next-up %}
+                                {% ifequal next-up.sponsor current-user %}
 
-                            <form method="POST" action="{{uris.spacy..app/schedule-session}}">
-                                <input type="hidden" name="id" value="{{next-up.session.id}}">
-                                <input type="hidden" name="room" value="{{room}}">
-                                <input type="hidden" name="time" value="{{time}}">
-                                <button>
-                                    Choose Slot <span class="visually-hidden">Room {{room}}, Time {{time}}</span>
-                                </button>
-                            </form>
+                                <hijax-form>
+                                    <form method="POST" action="{{uris.spacy..app/schedule-session}}">
+                                        <input type="hidden" name="id" value="{{next-up.session.id}}">
+                                        <input type="hidden" name="room" value="{{room}}">
+                                        <input type="hidden" name="time" value="{{time}}">
+                                        <button>
+                                            Choose Slot <span class="visually-hidden">Room {{room}}, Time {{time}}</span>
+                                        </button>
+                                    </form>
+                                </hijax-form>
 
-                            {% endifequal %}
-                            {% endif %}
-                            {% endifequal %}
-                            {% endifequal %}
+                                {% endifequal %}
+                                {% endif %}
+                                {% endifequal %}
+                                {% endifequal %}
 
+                                {% endfor %}
+                            </td>
                             {% endfor %}
-                        </td>
+                        </tr>
                         {% endfor %}
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+                    </tbody>
+                </table>
+            </div>
         </div>
+        <template>
+            <h-include src="{{uris.spacy..app/event}}" fragment="bulletin-board .schedule"></h-include>
+        </template>
     </bulletin-board>
-    <waiting-queue>
+    <new-session>
         <h2 id="new-session">Suggest a new session</h3>
         <hijax-form>
             <form method="POST" action="{{uris.spacy..app/submit-session}}">
@@ -114,11 +121,13 @@
                 <button type="submit">Submit Session</button>
             </form>
         </hijax-form>
+    </new-session>
+    <waiting-queue>
         <h2 id="queue">Queue</h2>
         <ol>
             {% for item in waiting-queue %}
             <li>
-                <details class="session" id="{{item.session.id}}">
+                <details class="session" data-id="{{item.session.id}}">
                     <summary>
                         {{item.session.title}} - {{item.sponsor}}
                     </summary>
@@ -128,7 +137,7 @@
             {% endfor %}
         </ol>
     </waiting-queue>
-    <user-notifications current-user="{{current-user}}" hidden role="log" aria-live="polite">
+    <user-notifications class="visually-hidden" current-user="{{current-user}}" hidden role="log" aria-live="polite">
         <h2 id="notifications">Notifications</h2>
         <details open>
             <summary>Toggle Notifications</summary>
@@ -141,12 +150,18 @@
                 <div data-slot="at"></div>
             </li>
         </template>
+        <template data-template="spacy.domain/session-scheduled">
+            <li>
+                The session "<span data-slot="title"></span>" from <span data-slot="sponsor"></span> has been scheduled at <span data-slot="time"></span> in
+                <span data-slot="room"></span>
+            </li>
+        </template>
     </user-notifications>
     <fact-handler uri="{{uris.spacy..app/sse}}"></fact-handler>
 
     <template id="session-template">
         <li>
-            <details class="session" id>
+            <details class="session" data-id>
                 <summary>
                     <span data-slot="title"></span> - <span data-slot="sponsor"></span>
                 </summary>

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -17,20 +17,27 @@
     </nav>
 </header>
 <main data-layout="event">
-    <up-next current-user="{{current-user}}">
-        <div data-content-slot>
-            {% if next-up %}
-            {% ifequal next-up.sponsor current-user %}
-            <p role="status">
+    <up-next current-user="{{current-user}}" up-next="{{is-next-up}}" aria-live="polite">
+        <p role="status">
+            {% if is-next-up %}
                 You are currently next in line! Please <a href="#sessions">select a slot</a> for your session "{{next-up.session.title}}".
-            </p>
-            {% endifequal %}
+            {% else %}
+                {% if next-up %}
+                    Please wait for others to present their sessions.
+                {% else %}
+                    There are currently no sessions in the queue.
+                {% endif %}
             {% endif %}
-        </div>
-        <template data-template="up-next">
-            <p role="status">
-                You are currently next in line! Please <a href="#sessions">select a slot</a> for your session "<span data-slot="title"></span>".
-            </p>
+        </p>
+
+        <template data-template="spacy.ui/up-next">
+            You are currently next in line! Please <a href="#sessions">select a slot</a> for your session "<span data-slot="title"></span>".
+        </template>
+        <template data-template="spacy.ui/please-wait">
+            Please wait for others to present their sessions.
+        </template>
+        <template data-template="spacy.ui/nobody-in-queue">
+            There are currently no sessions in the queue.
         </template>
     </up-next>
     <new-session>
@@ -90,8 +97,7 @@
 
                                 {% ifequal room slot.room %}
                                 {% ifequal time slot.time %}
-                                {% if next-up %}
-                                {% ifequal next-up.sponsor current-user %}
+                                {% if is-next-up %}
 
                                 <hijax-form>
                                     <form method="POST" action="{{uris.spacy..app/schedule-session}}">
@@ -104,7 +110,6 @@
                                     </form>
                                 </hijax-form>
 
-                                {% endifequal %}
                                 {% endif %}
                                 {% endifequal %}
                                 {% endifequal %}

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -9,8 +9,8 @@
 
     <nav>
         <ul>
-            <li><a href="#sessions">Sessions</a></li>
             <li><a href="#new-session">Suggest a new session</a></li>
+            <li><a href="#sessions">Sessions</a></li>
             <li><a href="#queue">Queue</a></li>
             <li class="js-only visually-hidden"><a href="#notifications">Notifications</a></li>
         </ul>
@@ -33,6 +33,22 @@
             </p>
         </template>
     </up-next>
+    <new-session>
+        <h2 id="new-session">Suggest a new session</h3>
+        <hijax-form>
+            <form method="POST" action="{{uris.spacy..app/submit-session}}">
+                <label>
+                    Title
+                    <input type="text" name="title" required>
+                </label>
+                <label>
+                    Description
+                    <textarea name="description" required></textarea>
+                </label>
+                <button type="submit">Submit Session</button>
+            </form>
+        </hijax-form>
+    </new-session>
     <bulletin-board>
         <h2 id="sessions">Sessions</h2>
         <div class="schedule">
@@ -106,22 +122,6 @@
             <h-include src="{{uris.spacy..app/event}}" fragment="bulletin-board .schedule"></h-include>
         </template>
     </bulletin-board>
-    <new-session>
-        <h2 id="new-session">Suggest a new session</h3>
-        <hijax-form>
-            <form method="POST" action="{{uris.spacy..app/submit-session}}">
-                <label>
-                    Title
-                    <input type="text" name="title" required>
-                </label>
-                <label>
-                    Description
-                    <textarea name="description" required></textarea>
-                </label>
-                <button type="submit">Submit Session</button>
-            </form>
-        </hijax-form>
-    </new-session>
     <waiting-queue>
         <h2 id="queue">Queue</h2>
         <ol>

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -54,7 +54,9 @@
         (->
          event
          (assoc :current-user "joy") ;; TODO - replace with user from header
-         (assoc :uris {::sse
+         (assoc :uris {::event
+                       (bidi/path-for routes ::event :event-slug slug)
+                       ::sse
                        (bidi/path-for routes ::sse :event-slug slug)
                        ::submit-session
                        (bidi/path-for routes ::submit-session :event-slug slug)


### PR DESCRIPTION
This PR is based off of #24 so that should be reviewed first.

When analysing the problem of how to correctly trigger the "up-next" event,
I realized that this is only an issue with the front-end and not an issue with
the back-end, so instead of implementing this as a fact in the back-end (I
honestly just felt like I was messing up our back-end domain model by trying
to add that fact to it), I decided to create this exclusively as a front-end
CustomEvent.

The waiting-queue custom element in the UI can calculate the current length
of the queue and fire a specific spacy.ui/app event whenever a new element
appears at the beginning of the list. Then the up-next and bulletin-board
custom elements can listen to this event and update their internal state.