### PR TITLE
   Store Crux logs in a relational database

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,10 @@
    [enlive "1.1.6"]
    [aero "1.1.6"]
    [juxt/crux-core "20.09-1.12.1-beta"]
+   [juxt/crux-jdbc "20.09-1.12.1-beta"]
+   [org.postgresql/postgresql "42.2.18"]
    [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]]
   :repl-options {:init-ns user}
 
-  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.5"]]}})
+  :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.2.5"]
+                                  [org.xerial/sqlite-jdbc "3.34.0"]]}})

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,2 +1,6 @@
 ;; This uses https://github.com/juxt/aero
-{:webserver {:port 9215}}
+{:webserver {:port 9215}
+ :crux {:db-spec #profile {:dev {:dbtype "sqlite"
+                                 :dbname "dev.db"}
+                           :prod {:dbtype "sqlite"
+                                  :dbname "prod.db"}}}}

--- a/src/spacy/config.clj
+++ b/src/spacy/config.clj
@@ -8,3 +8,6 @@
 
 (defn webserver [config]
   (:webserver config))
+
+(defn crux [config]
+  (:crux config))

--- a/src/spacy/crux.clj
+++ b/src/spacy/crux.clj
@@ -88,8 +88,10 @@
       (assoc component :node node)))
 
   (stop [component]
-    (save-seeds! (crux/db node))
-    (.close node)
+    (log/debug "Stopping" node)
+    (when node
+      (save-seeds! (crux/db node))
+      (.close node))
     (dissoc component :node))
 
   data/Events

--- a/src/spacy/system.clj
+++ b/src/spacy/system.clj
@@ -13,8 +13,8 @@
   (log/infof "Creating server listening on http://localhost:%s" port)
   (new-webserver :port port))
 
-(defn new-data []
-  (crux/map->Crux {}))
+(defn new-data [config]
+  (crux/map->Crux {:config config}))
 
 (defrecord FactChannel [channel mult-channel]
   component/Lifecycle
@@ -33,7 +33,7 @@
   (component/system-map
    :fact-channel (new-fact-channel)
    :data (component/using
-           (new-data)
+           (new-data (config/crux config))
            [:fact-channel])
    :app (component/using
          (app/new-app)


### PR DESCRIPTION
Prior to this commit we stored Crux logs in memory. Now they're kept
in a database using JDBC. For the time being it's SQLite. I also tested
it locally with Postgres. A corresponding db-spec looks as follows:

    {:dbtype "postgres"
     :dbname "postgres"
     :host "localhost"
     :user "postgres"
     :password "do not store passwords in git"}

See also https://opencrux.com/reference/jdbc.html

Once we end up switching to Postgres in production we might want to give
the following paragraph a careful read:

https://github.com/juxt/aero/blob/743e9bc495425b4a4a7c780f5e4b09f6680b4e7a/README.md#hide-passwords-in-local-private-files

I'm extending clojure.core/print-method for Crux to prevent printing
passwords when logging.

Related to #30 