### PR TITLE
Specify allowed ::fact values

### DIFF
--- a/src/spacy/domain.clj
+++ b/src/spacy/domain.clj
@@ -54,27 +54,42 @@
 (s/def ::facts
   (s/coll-of (s/or :scheduled ::scheduled
                    :suggested ::suggested
-                   :deleted ::deleted)))
+                   :moved     ::moved
+                   :deleted   ::deleted)))
+
+(defn fact-is [kind]
+  (fn [fact] (= kind (::fact fact))))
 
 (s/def ::scheduled
-  (s/keys :req [::sponsor
-                ::session
-                ::room
-                ::time
-                ::at
-                ::id]))
+  (s/and (fact-is ::session-scheduled)
+         (s/keys :req [::sponsor
+                       ::session
+                       ::room
+                       ::time
+                       ::at
+                       ::id])))
 
 (s/def ::suggested
-  (s/keys :req [::sponsor
-                ::session
-                ::at
-                ::id]))
+  (s/and (fact-is ::session-suggested)
+         (s/keys :req [::sponsor
+                       ::session
+                       ::at
+                       ::id])))
+
+(s/def ::moved
+  (s/and (fact-is ::session-moved)
+         (s/keys :req [::sponsor
+                       ::session
+                       ::at
+                       ::id])))
 
 (s/def ::deleted
-  (s/keys :req [::sponsor
-                ::session
-                ::at
-                ::id]))
+  (s/and (fact-is ::session-deleted)
+         (s/keys :req [::sponsor
+                       ::session
+                       ::at
+                       ::id])))
+
 
 (s/def ::at
   inst?)


### PR DESCRIPTION
See it fail with this unexpected fact:

    (s/explain ::facts [{::fact ::session-surprise
                         ::sponsor "hi"
                         ::session {::description "desc"
                                    ::title "title"
                                    ::id (java.util.UUID/randomUUID)}
                         ::id (java.util.UUID/randomUUID)
                         ::at (java.util.Date.)}])

Fixes #44