### PR TITLE
Move session

### DIFF
--- a/assets/components/bulletin-board/element.js
+++ b/assets/components/bulletin-board/element.js
@@ -4,6 +4,7 @@ export class BulletinBoard extends HTMLElement {
   connectedCallback() {
     document.body.addEventListener("spacy.domain/session-scheduled", this.reloadBoard.bind(this));
     document.body.addEventListener("spacy.domain/session-deleted", this.reloadBoard.bind(this));
+    document.body.addEventListener("spacy.domain/session-moved", this.reloadBoard.bind(this));
     document.body.addEventListener("spacy.ui/up-next", this.reloadBoard.bind(this));
   }
 

--- a/assets/styles/index.scss
+++ b/assets/styles/index.scss
@@ -29,6 +29,10 @@ a:hover, a:focus {
   color: $blue-600;
 }
 
+small {
+  font-style: italic;
+}
+
 // INPUT STYLING
 
 label {

--- a/resources/templates/event/commands.html
+++ b/resources/templates/event/commands.html
@@ -11,5 +11,13 @@
           </button>
       </form>
     </hijax-form>
+    <form method="POST" data-command="move-session" action>
+      <input type="hidden" name="id" value>
+      <input type="hidden" name="room" value>
+      <input type="hidden" name="time" value>
+      <button>
+          Move to slot <span class="visually-hidden">Room <span data-slot="room"></span>, Time <span data-slot="time"></span>
+      </button>
+    </form>
   </body>
 </html>

--- a/resources/templates/event/session.html
+++ b/resources/templates/event/session.html
@@ -10,13 +10,19 @@
       </details>
       <div class="toolbar" is-sponsor>
         <hijax-form>
-          <form method="POST" action>
+          <form data-command="delete-session" method="POST" action>
               <input type="hidden" name="id">
               <button>
                 Delete Session
               </button>
           </form>
         </hijax-form>
+        <form data-command="move-session" method="GET" action>
+          <input type="hidden" name="id">
+          <button>
+            Move Session
+          </button>
+        </form>
       </div>
     </div>
   </body>

--- a/resources/templates/move-session.html
+++ b/resources/templates/move-session.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Move Session</title>
+        <link rel="stylesheet" href="/bundle.css" />
+    </head>
+    <body>
+        <main>
+            <h1>Move Session</h1>
+            <h2>Session to move</h2>
+            <div class="session"></div>
+            <bulletin-board id="sessions"></bulletin-board>
+
+            <fact-handler uri></fact-handler>
+        </main>
+
+        <script src="/bundle.js"></script>
+    </body>
+</html>

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -117,7 +117,8 @@
 
 (html/defsnippet bulletin-board-snippet "templates/event/bulletin-board.html"
   [:bulletin-board]
-  [{::domain/keys [schedule rooms times slug] :as event} current-user action active-session page-link]
+  [{::domain/keys [schedule rooms times slug] :as event} current-user
+   & {:keys [action active-session page-link]}]
   [:h-include] (html/set-attr :src page-link)
   [:table :thead [(html/attr= :scope "col")]] (html/clone-for [r rooms]
                                                            [:th] (html/content r))
@@ -143,9 +144,10 @@
   [:h1] (html/content event-name)
   [:up-next] (html/substitute (up-next event current-user))
   [:new-session] (html/substitute (new-session-snippet event current-user))
-  [:bulletin-board] (html/substitute (bulletin-board-snippet event current-user schedule-session-action
-                                                             (domain/next-up event)
-                                                             (bidi/path-for routes ::event :event-slug slug)))
+  [:bulletin-board] (html/substitute (bulletin-board-snippet event current-user
+                                                             :action schedule-session-action
+                                                             :active-session (domain/next-up event)
+                                                             :page-link (bidi/path-for routes ::event :event-slug slug)))
   [:waiting-queue] (html/substitute (waiting-queue-snippet event current-user))
   [:template#session-template] (html/content (session-snippet event {::domain/sponsor current-user} current-user))
   [(html/attr? :current-user)] (html/set-attr :current-user current-user)
@@ -203,9 +205,10 @@
    current-user
    {{::domain/keys [id]} ::domain/session :as active-session}]
   [:.session] (html/substitute (session-snippet event active-session current-user))
-  [:bulletin-board] (html/substitute (bulletin-board-snippet event current-user move-session-action
-                                                             active-session
-                                                             (str (bidi/path-for routes ::move-session :event-slug slug) "?id=" id)))
+  [:bulletin-board] (html/substitute (bulletin-board-snippet event current-user
+                                                             :action move-session-action
+                                                             :active-session active-session
+                                                             :page-link (str (bidi/path-for routes ::move-session :event-slug slug) "?id=" id)))
   [:.session :.toolbar] nil
   [:bulletin-board (html/attr= :data-id id)] (html/substitute (html/html [:small "Your session is currently here"]))
   [:fact-handler] (html/set-attr :uri (bidi/path-for routes ::sse :event-slug slug)))

--- a/src/spacy/crux.clj
+++ b/src/spacy/crux.clj
@@ -42,8 +42,10 @@
         new-facts (->> facts
                        (map (partial add-event-id event-id))
                        (map maybe-add-crux-id))]
-    (crux/submit-tx node (for [doc (cons event new-facts)]
-                           [:crux.tx/put doc]))))
+    (crux/await-tx
+     node
+     (crux/submit-tx node (for [doc (cons event new-facts)]
+                            [:crux.tx/put doc])))))
 
 (defn- seed! [node]
   (let [event (-> (slurp "session.edn")

--- a/src/spacy/domain.clj
+++ b/src/spacy/domain.clj
@@ -183,7 +183,7 @@
        (filter #(= id (get-in % [::session ::id])))
        first))
 
-(defn- find-in-schedule-by-id [id {::keys [schedule]}]
+(defn find-in-schedule-by-id [id {::keys [schedule]}]
   (->> schedule
        (filter #(= id (get-in % [::session ::id])))
        first))

--- a/src/spacy/handler_util.clj
+++ b/src/spacy/handler_util.clj
@@ -34,10 +34,12 @@
 
 (defn get-resource
   "Wrapper for yada resource"
-  [response-fn]
+  [response-fn & {:keys [parameters]
+                  :or {parameters {}}}]
   (yada/handler
     (yada/resource
-      {:access-control access/control
+     {:access-control access/control
+      :parameters parameters
        :methods
        {:get
         {:produces {:media-type "text/html"}


### PR DESCRIPTION
Closes #28 

This adds an HTML screen for `move-session` which renders the same bulletin-board as in the `event` template, but removing some elements (from that screen we don't want any actions ("delete", "move") to be shown, and we want to show some kind of placeholder in the screen where the current slot is actually positioned).

I also added an `(crux/await-tx ...)` wrapper within our `(persist! data event)` call, because the redirect was happening before the event had been persisted so the card did not move within the session schedule, and I added an optional `parameters` keyword argument to the `get-resource` function in `handler-util`.