### PR TITLE
Status refactoring

### DIFF
--- a/assets/components/new-session/index.scss
+++ b/assets/components/new-session/index.scss
@@ -2,4 +2,9 @@ new-session {
   button {
     @extend %button-primary;
   }
+
+  user-notifications {
+    display: block;
+    margin-bottom: $spacer-sm;
+  }
 }

--- a/assets/components/up-next/element.js
+++ b/assets/components/up-next/element.js
@@ -1,4 +1,5 @@
 import { fillTemplate } from "../util/template";
+import { replaceNode } from "uitil/dom";
 
 export class UpNext extends HTMLElement {
   connectedCallback() {
@@ -26,12 +27,11 @@ export class UpNext extends HTMLElement {
   }
 
   swapContent(content) {
-    this.statusElement.innerHTML = "";
-    this.statusElement.appendChild(content);
+    replaceNode(this.p, content);
   }
 
-  get statusElement() {
-    return this.querySelector("[role=status]");
+  get p() {
+    return this.querySelector("p");
   }
 
   get currentUser() {

--- a/assets/components/user-notifications/element.js
+++ b/assets/components/user-notifications/element.js
@@ -2,13 +2,11 @@ import { fillTemplate } from "../util/template";
 
 export class UserNotifications extends HTMLElement {
   connectedCallback() {
-    if (!this.entries) {
+    if (!this.status || !this.listenFor) {
       return;
     }
-    this.hidden = false;
 
-    document.body.addEventListener("spacy.domain/session-suggested", this.addNotification.bind(this));
-    document.body.addEventListener("spacy.domain/session-scheduled", this.addNotification.bind(this));
+    this.listenFor.forEach(fact => document.body.addEventListener(fact, this.addNotification.bind(this)));
   }
 
   addNotification(ev) {
@@ -16,43 +14,45 @@ export class UserNotifications extends HTMLElement {
     const session = ev.detail["spacy.domain/session"];
     const notification = this.newNotification(ev.type);
 
-    if (!session || !this.notifyFor(ev.type, sponsor) || !notification) {
+    this.status.innerHTML = '';
+
+    if (!session || !this.notifyFor(sponsor) || !notification) {
       return; // Add no notifications for things we don't understand
     }
 
     fillTemplate(notification, "title", session["spacy.domain/title"]);
     fillTemplate(notification, "sponsor", sponsor);
-    fillTemplate(notification, "at", new Date()); // TODO: use Crux timestamp, but deal with timezones
     fillTemplate(notification, "room", ev.detail["spacy.domain/room"]);
     fillTemplate(notification, "time", ev.detail["spacy.domain/time"]);
 
-    this.entries.appendChild(notification);
+    this.status.appendChild(notification);
   }
 
-  get entries() {
-    return this.querySelector("ul");
+  get status() {
+    return this.querySelector("small");
   }
 
   get currentUser() {
     return this.getAttribute("current-user");
   }
 
-  notifyFor(fact, sponsor) {
-    switch (fact) {
-      case "spacy.domain/session-scheduled":
-        return true;
-      default:
-        return sponsor === this.currentUser;
+  get listenFor() {
+    let nodes = this.querySelectorAll("[data-fact]");
+    return [...nodes].map(el => el.getAttribute("data-fact"));
+  }
+
+  notifyFor(sponsor) {
+    if (this.hasAttribute("notify-all")) {
+      return true;
     }
+    return sponsor === this.currentUser;
   }
 
   newNotification(fact) {
-    const template = this.querySelector(`template[data-template="${fact}"]`);
+    const template = this.querySelector(`template[data-fact="${fact}"]`);
     if (!template) {
       return;
     }
-    return template.content
-      .querySelector("*") // Find first true HTML node which will be our session markup
-      .cloneNode(true);
+    return template.content.cloneNode(true);
   }
 }

--- a/assets/components/user-notifications/index.scss
+++ b/assets/components/user-notifications/index.scss
@@ -1,10 +1,3 @@
 user-notifications {
-  details {
-    margin-top: $spacer-sm;
-  }
 
-  [data-slot=at] {
-    color: gray;
-    font-size: $font-size-sm;
-  }
 }

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -74,7 +74,9 @@ main[data-layout="event"] {
     "up-next"
     "new-session"
     "bulletin-board"
+    "notifications"
     "waiting-queue";
+  grid-gap: $spacer-sm;
   padding: $spacer-base $spacer-sm;
 
   up-next {
@@ -84,6 +86,20 @@ main[data-layout="event"] {
   bulletin-board {
     grid-area: bulletin-board;
     overflow: auto;
+  }
+
+  & > user-notifications {
+    grid-area: notifications;
+    position: sticky;
+    bottom: 0;
+    z-index: 1;
+
+    small:not(:empty) {
+      display: block;
+      padding: $spacer-xs $spacer-sm;
+      border: 1px dashed $gray-900;
+      background-color: $gray-50;
+    }
   }
 
   new-session {
@@ -110,7 +126,8 @@ main[data-layout="event"] {
     grid-template-areas:
       "up-next bulletin-board"
       "new-session bulletin-board"
-      "waiting-queue bulletin-board";
+      "waiting-queue bulletin-board"
+      "waiting-queue notifications";
     grid-template-columns: 20rem 1fr;
     grid-template-rows: min-content min-content 1fr;
     column-gap: $spacer-lg;

--- a/resources/messages.edn
+++ b/resources/messages.edn
@@ -14,8 +14,6 @@
       :new-session.no-display-name.link "set your display name"
       :new-session.no-display-name.2 " in order to be able to submit a session."
       :new-session.submit "Submit Session"
-      :notifications.heading "Notifications"
-      :notifications.toggle "Toggle Notifications"
       :notifications.msg.session-suggested ["Your session \"" [:span {:data-slot "title"}] "\" was received and placed in the queue."]
       :notifications.msg.session-scheduled ["The session \"" [:span {:data-slot "title"}] "\" from " [:span {:data-slot "sponsor"}] " will take place on "
                                             [:span {:data-slot "time"}] " in the " [:span {:data-slot "room"}] " room."]
@@ -48,8 +46,6 @@
       :new-session.no-display-name.link "setze einen Anzeigename"
       :new-session.no-display-name.2 " bevor Du dein erstes Thema vorschlägst."
       :new-session.submit "Thema vorschlagen"
-      :notifications.heading "Nachrichten"
-      :notifications.toggle "Nachrichten ein/ausklappen"
       :notifications.msg.session-suggested ["Dein Thema \"" [:span {:data-slot "title"}] "\" wurde empfangen und ist jetzt in der Warteschlange."]
       :notifications.msg.session-scheduled ["Das Thema \"" [:span {:data-slot "title"}] "\" von " [:span {:data-slot "sponsor"}] " findet am "
                                             [:span {:data-slot "time"}] " im Raum " [:span {:data-slot "room"}] " statt."]

--- a/resources/messages.edn
+++ b/resources/messages.edn
@@ -19,6 +19,8 @@
       :notifications.msg.session-suggested ["Your session \"" [:span {:data-slot "title"}] "\" was received and placed in the queue."]
       :notifications.msg.session-scheduled ["The session \"" [:span {:data-slot "title"}] "\" from " [:span {:data-slot "sponsor"}] " will take place on "
                                             [:span {:data-slot "time"}] " in the " [:span {:data-slot "room"}] " room."]
+      :notifications.msg.session-moved ["The session \"" [:span {:data-slot "title"}] "\" from " [:span {:data-slot "sponsor"}] " will has moved to the "
+                                        [:span {:data-slot "room"}] " room on " [:span {:data-slot "time"}] "."]
       :open-spaces "Open Spaces"
       :queue.heading "Queue"
       :session.title "Title"
@@ -26,7 +28,7 @@
       :session.description "Description"
       :session.move "Move Session"
       :sessions.heading "Sessions"
-      :up-next.status.up-next ["You are currently next in line! Please " [:a {:href "#sessions"} "select a slot"] " for your session \"${title}" [:span {:data-slot "title"}]"\""]
+      :up-next.status.up-next ["You are currently next in line! Please " [:a {:href "#sessions"} "select a slot"] " for your session \"" [:span {:data-slot "title"}] "\""]
       :up-next.status.please-wait "Please wait for others to present their session"
       :up-next.status.nobody-in-queue "There are currently no sessions in the queue"}
  :de {:lang "de"
@@ -51,12 +53,14 @@
       :notifications.msg.session-suggested ["Dein Thema \"" [:span {:data-slot "title"}] "\" wurde empfangen und ist jetzt in der Warteschlange."]
       :notifications.msg.session-scheduled ["Das Thema \"" [:span {:data-slot "title"}] "\" von " [:span {:data-slot "sponsor"}] " findet am "
                                             [:span {:data-slot "time"}] " im Raum " [:span {:data-slot "room"}] " statt."]
+      :notifications.msg.session-moved ["Das Thema \"" [:span {:data-slot "title"}] "\" von " [:span {:data-slot "sponsor"}] " wird jetzt im Raum "
+                                        [:span {:data-slot "room"}] " am " [:span {:data-slot "time"}] " stattfinden."]
       :queue.heading "Warteschlange"
       :session.title "Titel"
       :session.delete "Löschen"
       :session.description "Beschreibung"
       :session.move "Umziehen"
       :sessions.heading "Zeitplan"
-      :up-next.status.up-next ["Du bist als nächstes dran! Bitte  " [:a {:href "#sessions"} " wähle einen Zeitslot"] " für dein Thema \"${title}" [:span {:data-slot "title"}] "\"."]
+      :up-next.status.up-next ["Du bist als nächstes dran! Bitte  " [:a {:href "#sessions"} " wähle einen Zeitslot"] " für dein Thema \"" [:span {:data-slot "title"}] "\"."]
       :up-next.status.please-wait "Bitte warte während die anderen ihren Themen präsentieren."
       :up-next.status.nobody-in-queue "Es gibt aktuell keinen Themen in der Warteschlange"}}

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -15,7 +15,6 @@
                     <li><a href="#new-session"><msg key="new-session.heading"></msg></a></li>
                     <li><a href="#sessions"><msg key="sessions.heading"></msg></a></li>
                     <li><a href="#queue"><msg key="queue.heading"></msg></a></li>
-                    <li class="js-only visually-hidden"><a href="#notifications"><msg key="notifications.heading"></msg></a></li>
                 </ul>
             </nav>
         </header>

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -23,26 +23,21 @@
             <up-next></up-next>
             <new-session id="new-session"></new-session>
             <bulletin-board id="sessions"></bulletin-board>
-            <waiting-queue id="queue"></waiting-queue>
-            <user-notifications class="visually-hidden" current-user hidden role="log" aria-live="polite">
-                <h2 id="notifications"><msg key="notifications.heading"></msg></h2>
-                <details open>
-                    <summary><msg key="notifications.toggle"></msg></summary>
-                    <ul></ul>
-                </details>
+            <user-notifications current-user role="status" aria-live="polite" notify-all>
+                <small></small>
 
-                <template data-template="spacy.domain/session-suggested">
-                    <li>
-                        <msg key="notifications.msg.session-suggested"></msg>
-                    </li>
-                </template>
-                <template data-template="spacy.domain/session-scheduled">
-                    <li>
+                <template data-fact="spacy.domain/session-scheduled">
+                    <span role="region" aria-role="polite">
                         <msg key="notifications.msg.session-scheduled"></msg>
-                    </li>
+                    </span>
+                </template>
+                <template data-fact="spacy.domain/session-moved">
+                    <span role="region" aria-role="polite">
+                        <msg key="notifications.msg.session-moved"></msg>
+                    </span>
                 </template>
             </user-notifications>
-
+            <waiting-queue id="queue"></waiting-queue>
 
             <template id="session-template">
                 <li>

--- a/resources/templates/event/bulletin-board.html
+++ b/resources/templates/event/bulletin-board.html
@@ -26,7 +26,7 @@
         </div>
       </div>
       <template>
-          <h-include src fragment="bulletin-board .schedule"></h-include>
+        <h-include src fragment="bulletin-board .schedule"></h-include>
       </template>
     </bulletin-board>
   </body>

--- a/resources/templates/event/new-session.html
+++ b/resources/templates/event/new-session.html
@@ -8,6 +8,15 @@
         <a><msg key="new-session.no-display-name.link"></msg></a>
         <msg key="new-session.no-display-name.2"></msg>
       </p>
+      <user-notifications current-user role="status" aria-live="polite">
+        <small></small>
+
+        <template data-fact="spacy.domain/session-suggested">
+          <span role="region" aria-live="polite">
+            <msg key="notifications.msg.session-suggested"></msg>
+          </span>
+        </template>
+      </user-notifications>
       <hijax-form>
           <form method="POST" action>
               <label>

--- a/resources/templates/event/up-next.html
+++ b/resources/templates/event/up-next.html
@@ -1,10 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
   <body>
-    <up-next current-user up-next aria-live="polite">
-      <p role="status"></p>
+    <up-next current-user up-next>
+      <p data-status></p>
 
-      <template></template>
+      <template data-template="spacy.ui/up-next">
+        <p role="status" aria-live="polite">
+          <msg key="up-next.status.up-next"></msg>
+        </p>
+      </template>
+      <template data-template="spacy.ui/please-wait">
+        <p>
+          <msg key="up-next.status.please-wait"></msg>
+        </p>
+      </template>
+      <template data-template="spacy.ui/nobody-in-queue">
+        <p>
+          <msg key="up-next.status.nobody-in-queue"></msg>
+        </p>
+      </template>
     </up-next>
   </body>
 </html>

--- a/src/spacy/messages.clj
+++ b/src/spacy/messages.clj
@@ -21,7 +21,7 @@
 (defn replace [replacer message]
   (cond
     (string? message) (replacer message)
-    (sequential? message) (map replacer message)
+    (sequential? message) (mapv replacer message)
     :else message))
 
 (defn transformer [messages]


### PR DESCRIPTION
This refactors the user notification system (tested on screenreaders).
The hope is to find a system where user updates _that are actually useful_
are read out at the right time (only when something changed and we want
to inform the user about it).

I didn't really like the old usage of role=log, because the user only is
really interested in a status update once, and doesn't want to go back
and read old entries (this is an assumption. could be wrong about that).

So I've exchanged the role=log section for areas which are role=region
as well as aria-live=polite. I have (tried) to test this with a screenreader,
and it seems to work, but will need more testing in the future.