### PR TITLE
Remove hardcoded events

### DIFF
--- a/session.edn
+++ b/session.edn
@@ -1,5 +1,6 @@
 {:spacy.domain/slug "februar-2021-event",
  :spacy.domain/waiting-queue [],
+ :spacy.domain/name "Februar 2021 Event",
  :spacy.domain/rooms
  ["Berlin"
   "Monheim"

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -138,10 +138,10 @@
     (schedule-session-snippet event session room time)))
 
 (html/deftemplate event-template "templates/event.html"
-  [{:keys [event-name] ::domain/keys [slug] :as event} current-user messages]
+  [{::domain/keys [name slug] :as event} current-user messages]
   [(html/attr? :lang)] (html/set-attr :lang (:lang messages))
-  [:title] (html/content event-name)
-  [:h1] (html/content event-name)
+  [:title] (html/content name)
+  [:h1] (html/content name)
   [:up-next] (html/substitute (up-next event current-user messages))
   [:new-session] (html/substitute (new-session-snippet event current-user))
   [:bulletin-board] (html/substitute (bulletin-board-snippet event current-user
@@ -154,18 +154,13 @@
   [:fact-handler] (html/set-attr :uri (bidi/path-for routes ::sse :event-slug slug))
   [:msg] (messages/transformer messages))
 
-(defn event-view-model [{:keys [current-user] :as event}]
-  (-> event
-      (assoc :event-name "Februar 2021 Event")))
-
 (defn show-event [{:keys [data]}]
   (handler-util/get-resource
    (fn [ctx]
      (let [messages (messages/messages (messages/language ctx))
            slug (get-in ctx [:parameters :path :event-slug])
            current-user (access/current-user ctx)
-           event (-> (data/fetch data slug)
-                     event-view-model)]
+           event (data/fetch data slug)]
        (apply str (event-template event current-user messages))))))
 
 (defn event-path [slug]

--- a/src/spacy/crux.clj
+++ b/src/spacy/crux.clj
@@ -30,6 +30,14 @@
             (s/explain-str ::domain/event event))
     event))
 
+
+(defn- all-slugs [db]
+  (let [found (crux/q db
+                      {:find '[name slug]
+                       :where '[[e ::domain/slug slug]
+                                [e ::domain/name name]]})]
+    (seq found)))
+
 (defn- add-event-id [event-id doc]
   (assoc doc ::belongs-to-event event-id))
 
@@ -114,6 +122,9 @@
   data/Events
   (fetch [component slug]
     (fetch (crux/db node) slug))
+
+  (all-slugs [component]
+    (all-slugs (crux/db node)))
 
   (persist! [component outcome]
     (persist! node outcome)))

--- a/src/spacy/data.clj
+++ b/src/spacy/data.clj
@@ -2,4 +2,5 @@
 
 (defprotocol Events
   (fetch [this slug])
+  (all-slugs [this])
   (persist! [this outcome]))

--- a/src/spacy/domain.clj
+++ b/src/spacy/domain.clj
@@ -20,6 +20,7 @@
   (s/keys :req [::waiting-queue
                 ::times
                 ::rooms
+                ::name
                 ::schedule
                 ::slug]))
 
@@ -31,6 +32,9 @@
 
 (s/def ::rooms
   (s/coll-of ::room))
+
+(s/def ::name
+  string?)
 
 (s/def ::waiting-queue
   (s/coll-of ::queued-session))
@@ -229,6 +233,7 @@
                                    ::id (random-uuid)}}]
       ::rooms ["Berin" "Monheim"]
       ::times ["10:00 – 11:00"]
+      ::name "example event"
       ::schedule [{::sponsor "jans"
                    ::session {::title "Idris"
                               ::description "Ich liebe Typen"

--- a/test/spacy/domain_test.clj
+++ b/test/spacy/domain_test.clj
@@ -12,6 +12,7 @@
                                           #:spacy.domain{:title "Responsive and Accessible"
                                                          :description "Responsible!"
                                                          :id next-up}}]
+   ::domain/name "test event"
    ::domain/rooms ["Berlin" "Monheim"]
    ::domain/times ["10:00 - 11:00" "11:00 - 12:00"]
    ::domain/schedule [#:spacy.domain{:sponsor "jans"


### PR DESCRIPTION
This removes hardcoded events by adding event names to the model and fetching all event slugs from Crux.