### PR TITLE
Working on adding visually hidden information to a table

### DIFF
--- a/resources/templates/event/bulletin-board.html
+++ b/resources/templates/event/bulletin-board.html
@@ -19,7 +19,11 @@
                 <tbody role="rowgroup">
                   <tr role="row" role="row">
                     <th scope="row" role="rowheader"></th>
-                    <td role="cell"></td>
+                    <td role="cell">
+                      <slot-description class="visually-hidden" id>
+                        <msg key="commands.actions.room-time" room time></msg>
+                      </slot-description>
+                    </td>
                   </tr>
                 </tbody>
             </table>

--- a/resources/templates/event/commands.html
+++ b/resources/templates/event/commands.html
@@ -6,11 +6,8 @@
           <input type="hidden" name="id" value>
           <input type="hidden" name="room" value>
           <input type="hidden" name="time" value>
-          <button>
+          <button aria-describedby>
             <msg key="commands.schedule-session.action"></msg>
-            <span class="visually-hidden">
-              <msg key="commands.actions.room-time" room time></msg>
-            </span>
           </button>
       </form>
     </hijax-form>
@@ -18,11 +15,8 @@
       <input type="hidden" name="id" value>
       <input type="hidden" name="room" value>
       <input type="hidden" name="time" value>
-      <button>
+      <button aria-describedby>
         <msg key="commands.move-session.action"></msg>
-        <span class="visually-hidden">
-          <msg key="commands.actions.room-time" room time></msg>
-        </span>
       </button>
     </form>
   </body>


### PR DESCRIPTION
This adds visually hidden text fields with Room & Time information
into the table schedule. (see #62)

Since this information is now in the DOM, I've also modified the
.session element and the `Choose Slot` actions to reference this
information via the `aria-describedby` attribute in the DOM.

I'm not completely sure yet if this is the best solution. I've tested
it myself, but we need to get a screenreader expert to test it if we
want to be sure that the UX is optimal.