### PR TITLE
Refactor schedule session

### DIFF
--- a/assets/components/bulletin-board/index.scss
+++ b/assets/components/bulletin-board/index.scss
@@ -3,6 +3,10 @@ bulletin-board {
     @extend %button-secondary;
   }
 
+  .help {
+    margin-bottom: $spacer-sm;
+  }
+
   table {
     border: 1px solid $gray-500;
     padding: $spacer-sm;

--- a/assets/components/session/index.scss
+++ b/assets/components/session/index.scss
@@ -10,8 +10,25 @@
     margin-top: $spacer-xxs;
   }
 
+  dl {
+    display: flex;
+    font-size: $font-size-sm;
+    font-style: italic;
+    margin-bottom: 0;
+
+    dt {
+      &::after {
+        content: ":";
+      }
+    }
+
+    dd {
+      margin-left: $spacer-xs;
+    }
+  }
+
   .toolbar {
-    margin-top: $spacer-xs;
+    margin-top: $spacer-sm;
     display: flex;
     gap: $spacer-xxs;
   }

--- a/assets/components/waiting-queue/index.scss
+++ b/assets/components/waiting-queue/index.scss
@@ -20,6 +20,16 @@ waiting-queue {
         margin-bottom: $spacer-xs;
         display: block;
       }
+
+      [hidden] {
+        display: block;
+      }
+
+      @media (min-width: $breakpoint-desktop-up) {
+        [hidden] {
+          @include visually-hidden();
+        }
+      }
     }
   }
 }

--- a/assets/styles/_layout.scss
+++ b/assets/styles/_layout.scss
@@ -111,7 +111,7 @@ main[data-layout="event"] {
   }
 
   #sessions:target {
-    padding-top: $spacer-xl;
+    scroll-margin-top: $spacer-xl;
   }
 
   h2 {

--- a/resources/messages.edn
+++ b/resources/messages.edn
@@ -1,6 +1,6 @@
 {:en {:lang "en"
       :commands.schedule-session.action "Choose slot"
-      :commands.move-session.action "Move to slot"
+      :commands.move-session.action "Choose slot"
       :commands.actions.room-time "Room ${room}, Time ${time}"
       :login.h1 "Tell us who you are!"
       :login.help "Let us know the display name that you want to use for submitting sessions!"
@@ -28,6 +28,8 @@
       :session.schedule "Schedule session"
       :session.sponsor "Sponsor"
       :sessions.heading "Sessions"
+      :sessions.schedule.help "Choose a time and room for your session \"${title}\" by selecting a slot within the following schedule."
+      :sessions.schedule.help.a11y "You can find open slots by iterating through the table. Slots which are available will have a \"Choose Slot\" action."
       :up-next.status.up-next ["You are currently next in line! Please " [:a {:href "#sessions"} "select a slot"] " for your session \"" [:span {:data-slot "title"}] "\""]
       :up-next.status.please-wait "Please wait for others to present their session"
       :up-next.status.nobody-in-queue "There are currently no sessions in the queue"}
@@ -61,6 +63,8 @@
       :session.schedule "Zeitslot auswählen"
       :session.sponsor "Sponsor"
       :sessions.heading "Zeitplan"
+      :sessions.schedule.help "Wähle eine Zeit und Raum für dein Thema \"${title}\" innerhalb des folgenden Zeitplans."
+      :sessions.schedule.help.a11y "Du kannst offene Zeitslots finden, indem du durch die Tabelle iterierst. Zeitslots, die verfügbar sind, werden eine \"Slot wählen\" Schaltfläche haben."
       :up-next.status.up-next ["Du bist als nächstes dran! Bitte  " [:a {:href "#sessions"} " wähle einen Zeitslot"] " für dein Thema \"" [:span {:data-slot "title"}] "\"."]
       :up-next.status.please-wait "Bitte warte, während die anderen ihre Themen präsentieren."
       :up-next.status.nobody-in-queue "Es gibt aktuell keine Themen in der Warteschlange"}}

--- a/resources/messages.edn
+++ b/resources/messages.edn
@@ -25,6 +25,8 @@
       :session.delete "Delete Session"
       :session.description "Description"
       :session.move "Move Session"
+      :session.schedule "Schedule session"
+      :session.sponsor "Sponsor"
       :sessions.heading "Sessions"
       :up-next.status.up-next ["You are currently next in line! Please " [:a {:href "#sessions"} "select a slot"] " for your session \"" [:span {:data-slot "title"}] "\""]
       :up-next.status.please-wait "Please wait for others to present their session"
@@ -56,6 +58,8 @@
       :session.delete "Löschen"
       :session.description "Beschreibung"
       :session.move "Umziehen"
+      :session.schedule "Zeitslot auswählen"
+      :session.sponsor "Sponsor"
       :sessions.heading "Zeitplan"
       :up-next.status.up-next ["Du bist als nächstes dran! Bitte  " [:a {:href "#sessions"} " wähle einen Zeitslot"] " für dein Thema \"" [:span {:data-slot "title"}] "\"."]
       :up-next.status.please-wait "Bitte warte, während die anderen ihre Themen präsentieren."

--- a/resources/templates/event/bulletin-board.html
+++ b/resources/templates/event/bulletin-board.html
@@ -4,29 +4,35 @@
     <bulletin-board>
       <h2 id="sessions"><msg key="sessions.heading"></msg></h2>
       <div class="schedule">
-          <div class="horizontal-scroll">
-            <!-- The redundant roles are because when we style the table using CSS grid on
-            mobile, assistive technologies may no longer realize that it is a table. -->
-            <table role="table">
-                <thead role="rowgroup">
-                    <tr role="row">
-                        <th scole="col" role="columnheader">
-                          <span class="visually-hidden">Times</span>
-                        </th>
-                        <th scope="col" role="columnheader"></th>
-                    </tr>
-                </thead>
-                <tbody role="rowgroup">
-                  <tr role="row" role="row">
-                    <th scope="row" role="rowheader"></th>
-                    <td role="cell">
-                      <slot-description class="visually-hidden" id>
-                        <msg key="commands.actions.room-time" room time></msg>
-                      </slot-description>
-                    </td>
+        <p class="help">
+          <msg key="sessions.schedule.help" title="Foo"></msg>
+          <span class="visually-hidden">
+            <msg key="sessions.schedule.help.a11y"></msg>
+          </span>
+        </p>
+        <div class="horizontal-scroll">
+          <!-- The redundant roles are because when we style the table using CSS grid on
+          mobile, assistive technologies may no longer realize that it is a table. -->
+          <table role="table">
+              <thead role="rowgroup">
+                  <tr role="row">
+                      <th scole="col" role="columnheader">
+                        <span class="visually-hidden">Times</span>
+                      </th>
+                      <th scope="col" role="columnheader"></th>
                   </tr>
-                </tbody>
-            </table>
+              </thead>
+              <tbody role="rowgroup">
+                <tr role="row" role="row">
+                  <th scope="row" role="rowheader"></th>
+                  <td role="cell">
+                    <slot-description class="visually-hidden" id>
+                      <msg key="commands.actions.room-time" room time></msg>
+                    </slot-description>
+                  </td>
+                </tr>
+              </tbody>
+          </table>
         </div>
       </div>
       <template>

--- a/resources/templates/event/session.html
+++ b/resources/templates/event/session.html
@@ -3,12 +3,17 @@
   <body>
     <div class="session" data-id aria-labelledby="title">
       <details>
-        <summary>
-            <span data-slot="title" id="title"></span> - <span data-slot="sponsor"></span>
-        </summary>
+        <summary data-slot="title" id="title"></summary>
         <span data-slot="description"></span>
       </details>
+      <dl>
+        <dt><msg key="session.sponsor"></msg></dt>
+        <dd><span data-slot="sponsor"></span></dd>
+      </dl>
       <div class="toolbar" is-sponsor>
+        <a href="#sessions" hidden>
+          <msg key="session.schedule"></msg>
+        </a>
         <hijax-form>
           <form data-command="delete-session" method="POST" action>
               <input type="hidden" name="id">

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -127,12 +127,13 @@
   [(html/attr= :name "time")] (html/set-attr :value time)
   [(html/attr? :aria-describedby)] (html/set-attr :aria-describedby (slot-id room time)))
 
-
 (html/defsnippet bulletin-board-snippet "templates/event/bulletin-board.html"
   [:bulletin-board]
   [{::domain/keys [schedule rooms times slug] :as event} current-user
    & {:keys [action active-session page-link]}]
   [:h-include] (html/set-attr :src page-link)
+  [:.help] (fn [node] (when active-session node))
+  [(html/attr? :title)] (html/set-attr :title (get-in active-session [::domain/session ::domain/title]))
   [:table :thead [(html/attr= :scope "col")]] (html/clone-for [r rooms]
                                                            [:th] (html/content r))
   [:table :tbody [:tr]] (html/clone-for [t times]


### PR DESCRIPTION
Two changes:

Commit 1 (bdec38c) :

This restructures the `.session` component. The reason here is that the
way that the session title is currently formatted within the `<summary>`
elements causes empty strings to appear in the accessibility tree that
are labelled as being an "empty toggle" (#59)

This moves the sponsor out of the `<summary>` into a description list
underneath the `<details>` element and adds some styling to it.

Commit 2 (7506720):

This adds a `Schedule session` link to the session object itself which
is blended in when the session is at the top of the queue (I decided to
blend in the link as a progressive enhancement using CSS, because we
already have CSS rules which target the first element in the list).

This also adds some instructions for how to schedule a session that are
shown when you are next in the queue. I've also added some more specific
instructions which are visually hidden, because I think this is probably
more confusing for screenreader users who cannot see the table with all
of the "choose slot" buttons.

