### PR TITLE
Add keepalive event to the sse stream

### DIFF
--- a/assets/components/fact-handler/element.js
+++ b/assets/components/fact-handler/element.js
@@ -12,7 +12,9 @@ export class FactHandler extends HTMLElement {
     const data = JSON.parse(event.data);
     const fact = data["spacy.domain/fact"];
 
-    this.dispatchEvent(new CustomEvent(fact, { detail: data, bubbles: true }));
+    if (fact) {
+      this.dispatchEvent(new CustomEvent(fact, { detail: data, bubbles: true }));
+    }
   }
 
   get sseUri() {

--- a/project.clj
+++ b/project.clj
@@ -20,6 +20,7 @@
    [org.postgresql/postgresql "42.2.18"]
    [buddy/buddy-sign "3.2.0"]
    [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]
+   [jarohen/chime "0.3.2"]
    [org.tobereplaced/http-accept-headers "0.1.0"]]
   :repl-options {:init-ns user}
 

--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -258,7 +258,7 @@
    :redirect-to event-path))
 
 (defn sse-for-event [{{:keys [mult-channel]} :fact-channel}]
-  (handler-util/sse-stream mult-channel (map json/generate-string)))
+  (handler-util/sse-stream mult-channel json/generate-string))
 
 (def handler-map
   "Map route identifies to handler creator functions.


### PR DESCRIPTION
Attempt on #64 (need to test separately before closing the issue)

When you are running spacy behind a proxy, the proxy is likely to cut
off the connection if there is no activity after a specified period
of time (e.g. 1 minute). In a browser environment, this can also occur,
but the timeout is a lot longer (> 5 minutes).

In any case, we want to prevent our application from breaking the connection
off after such a short period of time, because it's possible that we could
have several longer breaks between presenting sessions.

In order to support this, I've built in a "keepalive" message which is sent
every 15 seconds and should keep the connection open (we will need to test
in a deployed environment if this really works).

I built it using the `chimes` library which generates periodic sequences
that will be written onto a core.async channel. We can then write the
content of this channel onto the channel which generates the SSE events.

NOTE: the yada implementation is not 100% correct -- according to the SSE
spec, any line you write onto the SSE stream which begins with a ":" is
considered a comment and will be ignored by SSE clients (like the
`EventSource` in the browser).

However, the yada server takes whatever is written onto the channel and
automatically writes that string with the prefix `data: ` onto the SSE
stream, so there is no possibility for us to create a true comment.

Instead, I just write the string "keepalive" onto the stream, which will
appear as `data: "keepalive"` on the stream. I then modified the
JavaScript code so that it will ignore events that do not have the format
that it expects.