### PR TITLE
Fix missing UI notification when a session is deleted

### DIFF
--- a/assets/components/user-notifications/element.js
+++ b/assets/components/user-notifications/element.js
@@ -10,18 +10,17 @@ export class UserNotifications extends HTMLElement {
   }
 
   addNotification(ev) {
-    const sponsor = ev.detail["spacy.domain/sponsor"];
     const session = ev.detail["spacy.domain/session"];
     const notification = this.newNotification(ev.type);
 
     this.status.innerHTML = '';
 
-    if (!session || !this.notifyFor(sponsor) || !notification) {
+    if (!session || !this.notifyFor(ev.detail) || !notification) {
       return; // Add no notifications for things we don't understand
     }
 
     fillTemplate(notification, "title", session["spacy.domain/title"]);
-    fillTemplate(notification, "sponsor", sponsor);
+    fillTemplate(notification, "sponsor", ev.detail["spacy.domain/sponsor"]);
     fillTemplate(notification, "room", ev.detail["spacy.domain/room"]);
     fillTemplate(notification, "time", ev.detail["spacy.domain/time"]);
 
@@ -41,11 +40,14 @@ export class UserNotifications extends HTMLElement {
     return [...nodes].map(el => el.getAttribute("data-fact"));
   }
 
-  notifyFor(sponsor) {
+  notifyFor(fact) {
     if (this.hasAttribute("notify-all")) {
       return true;
     }
-    return sponsor === this.currentUser;
+    if (this.hasAttribute("notify-scheduled")) {
+      return fact["spacy.domain/room"] && fact["spacy.domain/time"];
+    }
+    return fact["spacy.domain/sponsor"] === this.currentUser;
   }
 
   newNotification(fact) {

--- a/resources/messages.edn
+++ b/resources/messages.edn
@@ -17,6 +17,8 @@
       :notifications.msg.session-suggested ["Your session \"" [:span {:data-slot "title"}] "\" was received and placed in the queue."]
       :notifications.msg.session-scheduled ["The session \"" [:span {:data-slot "title"}] "\" from " [:span {:data-slot "sponsor"}] " will take place on "
                                             [:span {:data-slot "time"}] " in the " [:span {:data-slot "room"}] " room."]
+      :notifications.msg.session-deleted ["The session \"" [:span {:data-slot "title"}] "\" from " [:span {:data-slot "sponsor"}] " was removed and will no longer take place at "
+                                            [:span {:data-slot "time"}] " in the " [:span {:data-slot "room"}] " room."]
       :notifications.msg.session-moved ["The session \"" [:span {:data-slot "title"}] "\" from " [:span {:data-slot "sponsor"}] " will has moved to the "
                                         [:span {:data-slot "room"}] " room on " [:span {:data-slot "time"}] "."]
       :open-spaces "Open Spaces"
@@ -52,6 +54,8 @@
       :new-session.submit "Thema vorschlagen"
       :notifications.msg.session-suggested ["Dein Thema \"" [:span {:data-slot "title"}] "\" wurde empfangen und ist jetzt in der Warteschlange."]
       :notifications.msg.session-scheduled ["Das Thema \"" [:span {:data-slot "title"}] "\" von " [:span {:data-slot "sponsor"}] " findet am "
+                                            [:span {:data-slot "time"}] " im Raum " [:span {:data-slot "room"}] " statt."]
+      :notifications.msg.session-deleted ["Das Thema \"" [:span {:data-slot "title"}] "\" von " [:span {:data-slot "sponsor"}] " wurde entfernt und findet nicht mehr am "
                                             [:span {:data-slot "time"}] " im Raum " [:span {:data-slot "room"}] " statt."]
       :notifications.msg.session-moved ["Das Thema \"" [:span {:data-slot "title"}] "\" von " [:span {:data-slot "sponsor"}] " wird jetzt
                                         am " [:span {:data-slot "time"}] " im Raum " [:span {:data-slot "room"}] " stattfinden."]

--- a/resources/templates/event.html
+++ b/resources/templates/event.html
@@ -22,7 +22,7 @@
             <up-next></up-next>
             <new-session id="new-session"></new-session>
             <bulletin-board id="sessions"></bulletin-board>
-            <user-notifications current-user role="status" aria-live="polite" notify-all>
+            <user-notifications current-user role="status" aria-live="polite" notify-scheduled>
                 <small></small>
 
                 <template data-fact="spacy.domain/session-scheduled">
@@ -33,6 +33,11 @@
                 <template data-fact="spacy.domain/session-moved">
                     <span role="region" aria-role="polite">
                         <msg key="notifications.msg.session-moved"></msg>
+                    </span>
+                </template>
+                <template data-fact="spacy.domain/session-deleted">
+                    <span role="region" aria-role="polite">
+                        <msg key="notifications.msg.session-deleted"></msg>
                     </span>
                 </template>
             </user-notifications>


### PR DESCRIPTION
Fixes #73

To fix this, I not only had to add the missing message to the markup,
but I also had to modify the user-notification custom element to have
a `notify-scheduled` option, because we only want the UI change to
trigger when a _scheduled_ session is deleted, not when a session is
deleted from the queue.

Because our facts still contain the `::room` and `::time` data when
the session was scheduled, I check for the existence of these
attributes to implement this option.