### PR TITLE
We want to remove the whole hijax-form when not logged in

### DIFF
--- a/src/spacy/app.clj
+++ b/src/spacy/app.clj
@@ -74,8 +74,8 @@
 (html/defsnippet new-session-snippet "templates/event/new-session.html"
   [:new-session]
   [{::domain/keys [slug]} current-user]
-  [:form] (when (not= current-user "nobody")
-            (html/set-attr :action (bidi/path-for routes ::submit-session :event-slug slug)))
+  [:hijax-form] (when (not= current-user "nobody") identity)
+  [:form] (html/set-attr :action (bidi/path-for routes ::submit-session :event-slug slug))
   [:p :a] (html/set-attr :href (str (bidi/path-for routes ::login)
                                 "?redirect=" (bidi/path-for routes ::event :event-slug slug)))
   [:p] (when (= current-user "nobody") identity))


### PR DESCRIPTION
Fixes #71

This fixes a bug -- we actually want to delete the wrapping
:hijax-form and not the :form element inside of it. By
deleting the :form element, the <hijax-form> element throws
a JavaScript exception