### PR TITLE
Prevent losing sessions due to race conditions

### DIFF
--- a/src/spacy/crux.clj
+++ b/src/spacy/crux.clj
@@ -63,7 +63,7 @@
     (if-not (crux/tx-committed? node tx)
       {::error ::concurrent-writes})))
 
-(def ^:private retries 5)
+(def ^:private retries 10)
 
 (defn- wait-after-attempt [attempt]
   {:pre [(<= 0 attempt retries)]}

--- a/src/spacy/data.clj
+++ b/src/spacy/data.clj
@@ -3,4 +3,6 @@
 (defprotocol Events
   (fetch [this slug])
   (all-slugs [this])
-  (persist! [this outcome]))
+  (update! [this slug f]
+    "Applies f to an event with a given slug and saves it.
+    Might call f multiple times. Throws on failure."))


### PR DESCRIPTION
Prior to this commit two concurrent writes often led to losing sessions.
Imagine the following scenario:

  - request A reads an event in state S
  - request B reads an event in state S
  - request B adds a session to S and saves the event state Sb
  - request A adds a session to S and saves the event state Sa

The client that sent B got a confirmation that their request was
successful. Alas, the event added by B is absent in Sa and lost.

This commit introduces a mechanism to make sure such race conditions do
not happen.

Upon saving the event state we use :crux.tx/match to make sure that no
concurrent writes occurred in the meantime. If there were no conflicts
the request is successful. Otherwise we retry the entire request after
a short wait.

If the request cannot be fulfilled after five retries, we give up and
throw an error. The number of times was chosen arbitrarily; it seems
to work.

After this patch the timeline would look as follows:

  - request A reads an event in state S
  - request B reads an event in state S
  - request B adds a session to S and tries to saves the state Sb
    (it's successful because the state in the database is S)
  - request A adds a session to S and tries to saves the state Sa
    (it's unsuccessful because the state in the database is Sb)
  - request A reads an event in state Sb
  - request A adds a session to Sb and tries to saves the state Sab
    (it's successful because the state in the database is Sb)

At this point the event has both sessions. No data loss occurs.

You can test this patch and see how many concurrent requests are
rejected using the following Ruby script.

    Threads = 8
    RequestsPerThread = 5

    puts "Firing #{Threads * RequestsPerThread} requests"

    Threads.times do |t|
      fork do
        RequestsPerThread.times do |n|
          sleep(rand)
          id = t * RequestsPerThread + n
          puts id
          print `curl -sSf http://localhost:9215/februar-2021-event/submit-session -d 'title=#{id}&description=desc#{id}'`
        end
      end
    end

    waited = Process.waitall
    puts "#{waited.count} children done"