### PR TITLE
Fixes #81 - Clear the action in a slot when the queue is empty

### DIFF
--- a/assets/components/slot-updater/element.js
+++ b/assets/components/slot-updater/element.js
@@ -11,7 +11,11 @@ export class SlotUpdater extends HTMLElement {
   }
 
   upNext(ev) {
-    this.appendAction(ev.detail);
+    if (ev.detail === "spacy.ui/nobody-in-queue") {
+      this.clearAction();
+    } else {
+      this.appendAction(ev.detail);
+    }
   }
 
   addScheduledSession(ev) {


### PR DESCRIPTION
When the queue is empty, the "spacy.ui/up-next" event is sent
with `{ detail: "spacy.ui/nobody-in-queue" }`. However, in the
`upNext` event of the `SlotUpdater` this was ignored and an
`appendAction` event was triggered. This fix now clears the
action when there is nobody in the queue.