### PR TITLE
Make adding session to queue idempotent

### DIFF
--- a/assets/components/waiting-queue/element.js
+++ b/assets/components/waiting-queue/element.js
@@ -28,6 +28,10 @@ export class WaitingQueue extends HTMLElement {
       console.error("Could not find session to add to queue.");
       return;
     }
+    if (this.sessionEntry(session["spacy.domain/id"])) {
+      console.error("Queue: Ignoring duplicate session received:", session["spacy.domain/id"]);
+      return;
+    }
     const element = createSession(sponsor, session, { parentWrapper: "li" });
 
     this.list.appendChild(element);


### PR DESCRIPTION
While using spacy during an event, one of the sessions that was
received to be placed in the queue appeared twice in the queue.
It is unclear as to why this occurred -- my assumption is that
the `::session-suggested` fact was for some reason sent twice
over the SSE Stream. It is also unclear to me why the session
would be sent twice (that's something we should look into),
but I also think it makes sense to modify the UI component
for the waiting-queue so that it is idempotent -- if the session
is sent twice to the UI, the second occurence will be ignored.

How to test this change:

Start the asset pipeline to make sure that the newest assets
are compiled:

```
npm start
```

in the Spacy repl:

```clojure
> (go)
> (require '[spacy.data :as data])
> (require '[spacy.domain :as domain])
> (require '[clojure.core.async :as async])
> (def state (data/fetch (:data system) "februar-2021-event"))
> (def fact (first (::domain/facts (domain/suggest-session state "Joy" {:title "Foo" :description "Bar"}))))
```

Now you can trigger adding of sessions in the UI if you have
opened the application on http://localhost:9215/februar-2021-event/

```
(async/go (async/>! (:channel (:fact-channel system)) fact))
```

The first time that this function is evaluated, the session will appear in
the UI. If the same exact function is evaluated, the UI will ignore the
session and print an error message to the console.