### PR TITLE
Updating Dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,23 +4,23 @@
   :license {:name "Apache License 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies
-  [[org.clojure/clojure "1.10.1"]
-   [org.clojure/core.async "1.3.610"]
-   [org.clojure/tools.logging "0.3.1"]
-   [ch.qos.logback/logback-classic "1.1.3"]
+  [[org.clojure/clojure "1.10.3"]
+   [org.clojure/core.async "1.5.644"]
+   [org.clojure/tools.logging "1.2.1"]
+   [ch.qos.logback/logback-classic "1.2.8"]
    [com.stuartsierra/component "1.0.0"]
-   [yada "1.2.15"]
+   [yada "1.2.16"]
    [bidi "2.1.6"]
    [juxt.modular/bidi "0.9.5"]
    [juxt.modular/aleph "0.1.4"]
    [enlive "1.1.6"]
    [aero "1.1.6"]
-   [com.xtdb/xtdb-core "1.19.0"]
-   [com.xtdb/xtdb-jdbc "1.19.0"]
-   [org.postgresql/postgresql "42.2.18"]
-   [buddy/buddy-sign "3.2.0"]
+   [com.xtdb/xtdb-core "1.20.0"]
+   [com.xtdb/xtdb-jdbc "1.20.0"]
+   [org.postgresql/postgresql "42.3.1"]
+   [buddy/buddy-sign "3.4.1"]
    [javax.xml.bind/jaxb-api "2.4.0-b180830.0359"]
-   [jarohen/chime "0.3.2"]
+   [jarohen/chime "0.3.3"]
    [org.tobereplaced/http-accept-headers "0.1.0"]]
   :repl-options {:init-ns user}
 


### PR DESCRIPTION
Updates all dependencies to the newest version.

This is perhaps all the more crucial because of a possible vulnerability with `logback` with a Version < 1.2.8 : https://logback.qos.ch/news.html (although this vulnerability seems less of an issue than the `log4j` debacle)